### PR TITLE
add flag to print out vir, add shorter Debug formatting for Spanned and Span

### DIFF
--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -1,12 +1,19 @@
 use std::rc::Rc;
+use std::fmt::Debug;
 
 pub type RawSpan = Rc<dyn std::any::Any>;
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Span {
     pub raw_span: RawSpan,
     pub as_string: String,
 }
 pub type SpanOption = Rc<Option<Span>>;
+
+impl Debug for Span {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_tuple("Span").field(&self.as_string).finish()
+    }
+}
 
 #[derive(Debug)]
 pub enum ValidityResult {

--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -1,5 +1,5 @@
-use std::rc::Rc;
 use std::fmt::Debug;
+use std::rc::Rc;
 
 pub type RawSpan = Rc<dyn std::any::Any>;
 #[derive(Clone)]

--- a/verify/rust_verify/src/config.rs
+++ b/verify/rust_verify/src/config.rs
@@ -42,7 +42,11 @@ pub(crate) fn take_our_args(args: &mut Vec<String>) -> Args {
             }
             args.remove(i);
             args.remove(i);
-        } else if arg == "--log_vir" || arg == "--log_air" || arg == "--log_air_final" || arg == "--log_smt" {
+        } else if arg == "--log_vir"
+            || arg == "--log_air"
+            || arg == "--log_air_final"
+            || arg == "--log_smt"
+        {
             match next_arg {
                 None => panic!("expected filename after {}", arg),
                 Some(filename) => {

--- a/verify/rust_verify/src/config.rs
+++ b/verify/rust_verify/src/config.rs
@@ -1,12 +1,14 @@
+#[derive(Debug, Default)]
 pub(crate) struct Args {
     pub(crate) rlimit: u32,
+    pub(crate) log_vir: Option<String>,
     pub(crate) log_air_initial: Option<String>,
     pub(crate) log_air_final: Option<String>,
     pub(crate) log_smt: Option<String>,
 }
 
 pub(crate) fn take_our_args(args: &mut Vec<String>) -> Args {
-    let mut a = Args { rlimit: 0, log_air_initial: None, log_air_final: None, log_smt: None };
+    let mut a: Args = Default::default();
     let mut i = 1;
     if args.len() == i {
         args.push("--help".to_string());
@@ -25,6 +27,7 @@ pub(crate) fn take_our_args(args: &mut Vec<String>) -> Args {
             println!(
                 "    --rlimit INTEGER              Set SMT resource limit (roughly in seconds)"
             );
+            println!("    --log_vir FILENAME            Log VIR");
             println!("    --log_air FILENAME            Log AIR queries in initial form");
             println!("    --log_air_final FILENAME      Log AIR queries in final form");
             println!("    --log_smt FILENAME            Log SMT queries");
@@ -39,11 +42,13 @@ pub(crate) fn take_our_args(args: &mut Vec<String>) -> Args {
             }
             args.remove(i);
             args.remove(i);
-        } else if arg == "--log_air" || arg == "--log_air_final" || arg == "--log_smt" {
+        } else if arg == "--log_vir" || arg == "--log_air" || arg == "--log_air_final" || arg == "--log_smt" {
             match next_arg {
                 None => panic!("expected filename after {}", arg),
                 Some(filename) => {
-                    if arg == "--log_air" {
+                    if arg == "--log_vir" {
+                        a.log_vir = Some(filename);
+                    } else if arg == "--log_air" {
                         a.log_air_initial = Some(filename);
                     } else if arg == "--log_air_final" {
                         a.log_air_final = Some(filename);

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -95,11 +95,18 @@ impl rustc_driver::Callbacks for Verifier {
             let hir = tcx.hir();
             let vir_crate = crate::rust_to_vir::crate_to_vir(tcx, hir.krate());
             if let Some(filename) = &self.args.log_vir {
-                let mut file = File::create(filename).expect(&format!("could not open file {}", filename));
+                let mut file =
+                    File::create(filename).expect(&format!("could not open file {}", filename));
                 for func in vir_crate.iter() {
-                    writeln!(&mut file, "fn {} @ {:?}", func.x.name, func.span).expect("cannot write to vir file");
+                    writeln!(&mut file, "fn {} @ {:?}", func.x.name, func.span)
+                        .expect("cannot write to vir file");
                     for param in func.x.params.iter() {
-                        writeln!(&mut file, "parameter {}: {:?} @ {:?}", param.x.name, param.x.typ, param.span).expect("cannot write to vir file");
+                        writeln!(
+                            &mut file,
+                            "parameter {}: {:?} @ {:?}",
+                            param.x.name, param.x.typ, param.span
+                        )
+                        .expect("cannot write to vir file");
                     }
                     write!(&mut file, "body {:#?}", func.x.body).expect("cannot write to vir file");
                     writeln!(&mut file).expect("cannot write to vir file");

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -1,7 +1,8 @@
 use air::ast::Span;
 use std::rc::Rc;
+use std::ops::Deref;
+use std::fmt::Debug;
 
-#[derive(Debug)]
 pub struct Spanned<X> {
     pub span: Span,
     pub x: X,
@@ -10,5 +11,11 @@ pub struct Spanned<X> {
 impl<X> Spanned<X> {
     pub fn new(span: Span, x: X) -> Rc<Spanned<X>> {
         Rc::new(Spanned { span: span, x: x })
+    }
+}
+
+impl<X: Debug> Debug for Spanned<X> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        f.debug_tuple("Spanned").field(&self.span.as_string).field(&self.x).finish()
     }
 }

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -1,7 +1,7 @@
 use air::ast::Span;
-use std::rc::Rc;
-use std::ops::Deref;
 use std::fmt::Debug;
+use std::ops::Deref;
+use std::rc::Rc;
 
 pub struct Spanned<X> {
     pub span: Span,


### PR DESCRIPTION
This introduces a more compact `Debug` format for `Span` and `Spanned` and leverages it to print out the VIR AST if the `--log-vir` flag is present.

The output looks as follows (for `basic.rs`):
```
fn main @ Span("rust_verify/examples/basic.rs:4:1: 4:10 (#0)")
body Spanned(
    "rust_verify/examples/basic.rs:4:11: 4:13 (#0)",
    Block(
        [],
    ),
)

fn test1 @ Span("rust_verify/examples/basic.rs:6:1: 6:11 (#0)")
body Spanned(
    "rust_verify/examples/basic.rs:6:12: 15:2 (#0)",
    Block(
        [
            Spanned(
                "rust_verify/examples/basic.rs:7:5: 7:17 (#0)",
                Expr(
                    Spanned(
                        "rust_verify/examples/basic.rs:7:5: 7:17 (#0)",
                        Assert(
                            Spanned(
                                "rust_verify/examples/basic.rs:7:12: 7:16 (#0)",
                                Const(
                                    Bool(
                                        true,
                                    ),
                                ),
                            ),
                        ),
                    ),
                ),
            ),
```
[snip]