### PR TITLE
Switch to a custom `getopts` for both `air` and `rust_verify`

### DIFF
--- a/verify/air/Cargo.toml
+++ b/verify/air/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 z3 = "0.10.0"
 sise = "0.6.0"
-getopts = "0.2"
+getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }

--- a/verify/air/Cargo.toml
+++ b/verify/air/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2018"
 [dependencies]
 z3 = "0.10.0"
 sise = "0.6.0"
-clap = "2.33.3"
+getopts = "0.2"

--- a/verify/air/src/main.rs
+++ b/verify/air/src/main.rs
@@ -16,7 +16,7 @@ pub fn main() {
     opts.optflag("h", "help", "print this help menu");
 
     let print_usage = || {
-        let brief = format!("Usage: {} INPUT [options]", program);
+        let brief = format!("Usage: {} INPUT [OPTIONS]", program);
         eprint!("{}", opts.usage(&brief));
     };
 

--- a/verify/rust_verify/Cargo.toml
+++ b/verify/rust_verify/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 z3 = "0.10.0"
 air = { path = "../air" }
 vir = { path = "../vir" }
+getopts = { git = "https://github.com/utaal/getopts.git", branch = "parse-partial" }

--- a/verify/rust_verify/src/main.rs
+++ b/verify/rust_verify/src/main.rs
@@ -14,8 +14,6 @@ extern crate rustc_mir_build;
 extern crate rustc_span;
 extern crate rustc_typeck;
 
-use config::take_our_args;
-use std::env;
 use verifier::Verifier;
 
 struct CompilerCallbacks;
@@ -23,12 +21,13 @@ struct CompilerCallbacks;
 impl rustc_driver::Callbacks for CompilerCallbacks {}
 
 pub fn main() {
-    let mut args: Vec<String> = env::args().collect();
-    let our_args = take_our_args(&mut args);
+    let mut args = std::env::args();
+    let program = args.next().unwrap();
+    let (our_args, rustc_args) = config::parse_args(&program, args);
 
     // Run verifier callback to build VIR tree and run verifier
     let mut verifier = Verifier::new(our_args);
-    let status = rustc_driver::RunCompiler::new(&args, &mut verifier).run();
+    let status = rustc_driver::RunCompiler::new(&rustc_args, &mut verifier).run();
     println!(
         "Verification results:: verified: {} errors: {}",
         verifier.count_verified, verifier.count_errors
@@ -43,7 +42,7 @@ pub fn main() {
     // Run borrow checker and compiler (if enabled)
     let compile = false;
     if compile {
-        rustc_driver::RunCompiler::new(&args, &mut CompilerCallbacks)
+        rustc_driver::RunCompiler::new(&rustc_args, &mut CompilerCallbacks)
             .run()
             .expect("RunCompiler.run() failed");
     }


### PR DESCRIPTION
The custom `getopts` supports forwarding unmatched arguments to `rustc`, so we don't need custom logic for the parsing in `rust_verify`.