### PR TITLE
Add support for simple, immutable `let`

### DIFF
--- a/verify/rust_verify/example/basic.rs
+++ b/verify/rust_verify/example/basic.rs
@@ -33,3 +33,8 @@ fn test2(b: bool, x: int, y: int, z: int) {
     assert(x <= z);
     assert(x < z); // FAILS
 }
+
+fn test_assign(a: int, b: int) {
+    let c = a + b;
+    assert(c == a + b);
+}

--- a/verify/rust_verify/example/basic.rs
+++ b/verify/rust_verify/example/basic.rs
@@ -37,4 +37,9 @@ fn test2(b: bool, x: int, y: int, z: int) {
 fn test_assign(a: int, b: int) {
     let c = a + b;
     assert(c == a + b);
+
+    let d = false;
+    assert(!d);
+
+    assert(c < a + b); // FAILS
 }

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -12,7 +12,7 @@ pub enum Mode {
     Exec,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum Typ {
     Bool,
     Int,
@@ -60,6 +60,7 @@ pub type Stmts = Rc<Box<[Stmt]>>;
 #[derive(Debug)]
 pub enum StmtX {
     Expr(Expr),
+    Decl(ParamX),
 }
 
 pub type Param = Rc<Spanned<ParamX>>;

--- a/verify/vir/src/ast_to_sst.rs
+++ b/verify/vir/src/ast_to_sst.rs
@@ -61,5 +61,8 @@ pub fn expr_to_stm(ctx: &Ctx, expr: &Expr) -> Result<Stm, VirErr> {
 pub fn stmt_to_stm(ctx: &Ctx, stmt: &Stmt) -> Result<Stm, VirErr> {
     match &stmt.x {
         StmtX::Expr(expr) => expr_to_stm(ctx, &expr),
+        StmtX::Decl(param) => {
+            Ok(Spanned::new(stmt.span.clone(), StmX::Decl(param.name.clone(), param.typ)))
+        }
     }
 }

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -5,7 +5,7 @@ Whereas ast supports statements inside expressions,
 sst expressions cannot contain statments.
 */
 
-use crate::ast::{BinaryOp, UnaryOp};
+use crate::ast::{BinaryOp, Typ, UnaryOp};
 use crate::def::Spanned;
 use air::ast::{Const, Ident};
 use std::rc::Rc;
@@ -28,4 +28,5 @@ pub enum StmX {
     Assume(Exp),
     Assert(Exp),
     Block(Stms),
+    Decl(Ident, Typ),
 }

--- a/verify/vir/src/util.rs
+++ b/verify/vir/src/util.rs
@@ -1,4 +1,4 @@
-pub fn box_slice_map<A, B, F: Fn(&A) -> B>(slice: &[A], f: F) -> Box<[B]> {
+pub fn box_slice_map<A, B, F: FnMut(&A) -> B>(slice: &[A], f: F) -> Box<[B]> {
     slice.iter().map(f).collect::<Vec<B>>().into_boxed_slice()
 }
 


### PR DESCRIPTION
This example code:

```rust
fn test_assign(a: int, b: int) {
    let c = a + b;
    assert(c == a + b);
}
```

results in the following `air`:

```rust
;; Function-Def test_assign
(check-valid
 (declare-const a@ Int)
 (declare-const b@ Int)
 (declare-const c@ Int)
 (block
  (assume
   (= c@ (+ a@ b@))
  )
  (assert
   "rust_verify/example/basic.rs:39:12: 39:22 (#0)"
   (= c@ (+ a@ b@))
  )
 )
)
```

and verifies correctly.