### PR TITLE
Add support for simple, mutable `let`, and simple assignment

### DIFF
--- a/verify/rust_verify/example/basic.rs
+++ b/verify/rust_verify/example/basic.rs
@@ -43,3 +43,10 @@ fn test_assign(a: int, b: int) {
 
     assert(c < a + b); // FAILS
 }
+
+fn test_assign_mut(a: int, b: int) {
+    let mut c = a;
+    c = c + b;
+    assert(c == a + b);
+    assert(c == a); // FAILS
+}

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -53,6 +53,7 @@ pub enum ExprX {
     Unary(UnaryOp, Expr),
     Binary(BinaryOp, Expr, Expr),
     Block(Stmts),
+    Assign(Expr, Expr),
 }
 
 pub type Stmt = Rc<Spanned<StmtX>>;
@@ -60,7 +61,7 @@ pub type Stmts = Rc<Box<[Stmt]>>;
 #[derive(Debug)]
 pub enum StmtX {
     Expr(Expr),
-    Decl(ParamX),
+    Decl { param: ParamX, mutable: bool },
 }
 
 pub type Param = Rc<Spanned<ParamX>>;

--- a/verify/vir/src/ast_to_sst.rs
+++ b/verify/vir/src/ast_to_sst.rs
@@ -48,6 +48,10 @@ pub fn expr_to_stm(ctx: &Ctx, expr: &Expr) -> Result<Stm, VirErr> {
         ExprX::Assert(expr) => {
             Ok(Spanned::new(expr.span.clone(), StmX::Assert(expr_to_exp(ctx, expr)?)))
         }
+        ExprX::Assign(lhs, rhs) => Ok(Spanned::new(
+            expr.span.clone(),
+            StmX::Assign(expr_to_exp(ctx, lhs)?, expr_to_exp(ctx, rhs)?),
+        )),
         ExprX::Block(stmts) => {
             let stms = Rc::new(box_slice_map_result(stmts, |s| stmt_to_stm(ctx, s))?);
             Ok(Spanned::new(expr.span.clone(), StmX::Block(stms)))
@@ -61,8 +65,9 @@ pub fn expr_to_stm(ctx: &Ctx, expr: &Expr) -> Result<Stm, VirErr> {
 pub fn stmt_to_stm(ctx: &Ctx, stmt: &Stmt) -> Result<Stm, VirErr> {
     match &stmt.x {
         StmtX::Expr(expr) => expr_to_stm(ctx, &expr),
-        StmtX::Decl(param) => {
-            Ok(Spanned::new(stmt.span.clone(), StmX::Decl(param.name.clone(), param.typ)))
-        }
+        StmtX::Decl { param, mutable } => Ok(Spanned::new(
+            stmt.span.clone(),
+            StmX::Decl { ident: param.name.clone(), typ: param.typ, mutable: *mutable },
+        )),
     }
 }

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -28,5 +28,6 @@ pub enum StmX {
     Assume(Exp),
     Assert(Exp),
     Block(Stms),
-    Decl(Ident, Typ),
+    Decl { ident: Ident, typ: Typ, mutable: bool },
+    Assign(Exp, Exp),
 }


### PR DESCRIPTION
Rust example:

```rust
fn test_assign_mut(a: int, b: int) {
    let mut c = a;
    c = c + b;
    assert(c == a + b);
    assert(c == a); // FAILS
}
```

Air:

```
;; Function-Def test_assign_mut
(check-valid
 (declare-const a@ Int)
 (declare-const b@ Int)
 (declare-var c@ Int)
 (block
  (assume
   (= c@ a@)
  )
  (assign c@ (+ c@ b@))
  (assert
   "rust_verify/example/basic.rs:50:12: 50:22 (#0)"
   (= c@ (+ a@ b@))
  )
  (assert
   "rust_verify/example/basic.rs:51:12: 51:18 (#0)"
   (= c@ a@)
  )
 )
)
```

Verifies correctly.

