### PR TITLE
Add support for struct and enum declarations

### DIFF
--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -70,10 +70,19 @@ pub enum MultiOp {
 
 pub type Binder<A> = Rc<BinderX<A>>;
 pub type Binders<A> = Rc<Vec<Binder<A>>>;
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct BinderX<A: Clone> {
     pub name: Ident,
     pub a: A,
+}
+
+impl<A: Clone + Debug> std::fmt::Debug for BinderX<A> {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        self.name.fmt(fmt)?;
+        fmt.write_str(" -> ")?;
+        self.a.fmt(fmt)?;
+        Ok(())
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -76,6 +76,12 @@ pub struct BinderX<A: Clone> {
     pub a: A,
 }
 
+impl<A: Clone> BinderX<A> {
+    pub fn map_a<B: Clone>(&self, f: impl FnOnce(&A) -> B) -> BinderX<B> {
+        BinderX { name: self.name.clone(), a: f(&self.a) }
+    }
+}
+
 impl<A: Clone + Debug> std::fmt::Debug for BinderX<A> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.name.fmt(fmt)?;

--- a/verify/air/src/context.rs
+++ b/verify/air/src/context.rs
@@ -147,7 +147,11 @@ impl<'ctx> Context<'ctx> {
         let len = self.name_scopes.len();
         self.name_scopes[len - 1].push(x.clone());
         let prev = self.typing.names.insert(x.clone());
-        if prev { Ok(()) } else { Err(format!("name {} is already in scope", x)) }
+        if prev {
+            Ok(())
+        } else {
+            Err(format!("name {} is already in scope", x))
+        }
     }
 
     pub(crate) fn pop_name_scope(&mut self) {

--- a/verify/air/src/smt_verify.rs
+++ b/verify/air/src/smt_verify.rs
@@ -253,7 +253,8 @@ pub(crate) fn smt_add_decl<'ctx>(context: &mut Context<'ctx>, decl: &Decl) {
                     for field in variant.a.iter() {
                         match &*field.a {
                             TypX::Named(x) if names.contains(x) => {
-                                sorts1.push(Rc::new(Sort::bool(context.context))); // dummy sort
+                                sorts1.push(Rc::new(Sort::bool(context.context)));
+                                // dummy sort
                             }
                             _ => {
                                 sorts1.push(get_sort(context, &field.a));

--- a/verify/air/src/typecheck.rs
+++ b/verify/air/src/typecheck.rs
@@ -68,7 +68,11 @@ fn typ_eq(typ1: &Typ, typ2: &Typ) -> bool {
 }
 
 fn expect_typ(typ1: &Typ, typ2: &Typ, msg: &str) -> Result<(), TypeError> {
-    if typ_eq(typ1, typ2) { Ok(()) } else { Err(msg.to_string()) }
+    if typ_eq(typ1, typ2) {
+        Ok(())
+    } else {
+        Err(msg.to_string())
+    }
 }
 
 pub(crate) fn check_typ(typing: &Typing, typ: &Typ) -> Result<(), TypeError> {

--- a/verify/air/src/var_to_const.rs
+++ b/verify/air/src/var_to_const.rs
@@ -11,7 +11,11 @@ fn find_version(versions: &HashMap<Ident, u32>, x: &String) -> u32 {
 }
 
 fn rename_var(x: &String, n: u32) -> String {
-    if x.ends_with("@") { format!("{}{}", x, n) } else { format!("{}@{}", x, n) }
+    if x.ends_with("@") {
+        format!("{}{}", x, n)
+    } else {
+        format!("{}@{}", x, n)
+    }
 }
 
 pub(crate) fn lower_query(query: &Query) -> Query {

--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -1,0 +1,18 @@
+extern crate builtin;
+use builtin::{assert, assume, imply, int};
+
+struct Car {
+    four_doors: bool,
+    passengers: int,
+
+}
+
+enum Vehicle {
+    Car(Car),
+}
+
+fn main() {}
+
+// fn test1(p: int) {
+//     assert((Car { passengers: p }).passengers == p);
+// }

--- a/verify/rust_verify/src/main.rs
+++ b/verify/rust_verify/src/main.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod rust_to_vir;
+mod rust_to_vir_adts;
 mod rust_to_vir_expr;
 mod rust_to_vir_func;
 mod util;

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -110,10 +110,7 @@ fn check_attr<'tcx>(
     Ok(())
 }
 
-pub fn crate_to_vir<'tcx>(
-    tcx: TyCtxt<'tcx>,
-    krate: &'tcx Crate<'tcx>,
-) -> Result<Krate, VirErr> {
+pub fn crate_to_vir<'tcx>(tcx: TyCtxt<'tcx>, krate: &'tcx Crate<'tcx>) -> Result<Krate, VirErr> {
     let Crate {
         item: _,
         exported_macros,

--- a/verify/rust_verify/src/rust_to_vir_adts.rs
+++ b/verify/rust_verify/src/rust_to_vir_adts.rs
@@ -1,0 +1,90 @@
+use crate::rust_to_vir_expr::{hack_get_def_name, spanned_new, ty_to_vir};
+use crate::rust_to_vir_func::check_generics;
+use crate::{unsupported, unsupported_unless};
+use rustc_hir::{
+    Crate, EnumDef, Generics, ItemId, VariantData,
+};
+use rustc_middle::ty::TyCtxt;
+use rustc_span::Span;
+use std::rc::Rc;
+use vir::ast::{Ident, KrateX, Variant};
+use vir::ast_util::{ident_binder, str_ident};
+
+// TODO(andreal): move to adt file
+fn check_variant_data<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    _krate: &'tcx Crate<'tcx>,
+    name: &Ident,
+    variant_data: &'tcx VariantData<'tcx>,
+) -> Variant {
+    ident_binder(
+        name,
+        &(match variant_data {
+            VariantData::Struct(fields, recovered) => {
+                unsupported_unless!(!recovered, "recovered_struct", variant_data);
+                Rc::new(
+                    fields
+                        .iter()
+                        .map(|field| {
+                            ident_binder(
+                                &str_ident(&field.ident.as_str()),
+                                &ty_to_vir(tcx, field.ty),
+                            )
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            }
+            VariantData::Tuple(fields, _variant_id) => Rc::new(
+                fields
+                    .iter()
+                    .map(|field| {
+                        ident_binder(&str_ident(&field.ident.as_str()), &ty_to_vir(tcx, field.ty))
+                    })
+                    .collect::<Vec<_>>(),
+            ),
+            VariantData::Unit(_) => {
+                unsupported!("unit_adt", variant_data);
+            }
+        }),
+    )
+}
+
+// TODO(andreal): move to adt file
+pub fn check_item_struct<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    krate: &'tcx Crate<'tcx>,
+    vir: &mut KrateX,
+    span: Span,
+    id: &ItemId,
+    variant_data: &'tcx VariantData<'tcx>,
+    generics: &'tcx Generics<'tcx>,
+) {
+    check_generics(generics);
+    let name = Rc::new(hack_get_def_name(tcx, id.def_id.to_def_id()));
+    let variants = Rc::new(vec![check_variant_data(tcx, krate, &name, variant_data)]);
+    vir.datatypes.push(spanned_new(span, ident_binder(&name, &variants)));
+}
+
+// TODO(andreal): move to adt file
+pub fn check_item_enum<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    krate: &'tcx Crate<'tcx>,
+    vir: &mut KrateX,
+    span: Span,
+    id: &ItemId,
+    enum_def: &'tcx EnumDef<'tcx>,
+    generics: &'tcx Generics<'tcx>,
+) {
+    check_generics(generics);
+    let name = Rc::new(hack_get_def_name(tcx, id.def_id.to_def_id()));
+    let variants = Rc::new(
+        enum_def
+            .variants
+            .iter()
+            .map(|variant| {
+                check_variant_data(tcx, krate, &str_ident(&variant.ident.as_str()), &variant.data)
+            })
+            .collect::<Vec<_>>(),
+    );
+    vir.datatypes.push(spanned_new(span, ident_binder(&name, &variants)));
+}

--- a/verify/rust_verify/src/rust_to_vir_adts.rs
+++ b/verify/rust_verify/src/rust_to_vir_adts.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 use vir::ast::{Ident, KrateX, Variant};
 use vir::ast_util::{ident_binder, str_ident};
 
-// TODO(andreal): move to adt file
 fn check_variant_data<'tcx>(
     tcx: TyCtxt<'tcx>,
     _krate: &'tcx Crate<'tcx>,
@@ -47,7 +46,6 @@ fn check_variant_data<'tcx>(
     )
 }
 
-// TODO(andreal): move to adt file
 pub fn check_item_struct<'tcx>(
     tcx: TyCtxt<'tcx>,
     krate: &'tcx Crate<'tcx>,
@@ -64,7 +62,6 @@ pub fn check_item_struct<'tcx>(
     vir.datatypes.push(spanned_new(span, ident_binder(&Rc::new(name), &variants)));
 }
 
-// TODO(andreal): move to adt file
 pub fn check_item_enum<'tcx>(
     tcx: TyCtxt<'tcx>,
     krate: &'tcx Crate<'tcx>,

--- a/verify/rust_verify/src/rust_to_vir_expr.rs
+++ b/verify/rust_verify/src/rust_to_vir_expr.rs
@@ -20,6 +20,12 @@ pub(crate) fn spanned_new<X>(span: Span, x: X) -> Rc<Spanned<X>> {
     Spanned::new(air::ast::Span { raw_span, as_string }, x)
 }
 
+pub(crate) fn path_to_ty_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Typ {
+    let ds =
+        tcx.def_path(def_id).data.iter().map(|d| Rc::new(format!("{}", d))).collect::<Vec<_>>();
+    Typ::Path(ds)
+}
+
 // TODO: proper handling of def_ids
 pub(crate) fn hack_get_def_name<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> String {
     let debug_name = tcx.def_path_debug_str(def_id);
@@ -89,7 +95,7 @@ pub(crate) fn ty_to_vir<'tcx>(tcx: TyCtxt<'tcx>, ty: &Ty) -> Typ {
                 if hack_check_def_name(tcx, def_id, "builtin", "int") {
                     Typ::Int
                 } else {
-                    unsupported!(format!("type {:?} {:?}", kind, span))
+                    path_to_ty_path(tcx, def_id)
                 }
             }
             _ => {

--- a/verify/rust_verify/src/rust_to_vir_func.rs
+++ b/verify/rust_verify/src/rust_to_vir_func.rs
@@ -9,7 +9,7 @@ use rustc_mir_build::thir;
 use rustc_span::symbol::Ident;
 use rustc_span::Span;
 use std::rc::Rc;
-use vir::ast::{Function, FunctionX, Mode, ParamX, VirErr};
+use vir::ast::{FunctionX, KrateX, Mode, ParamX, VirErr};
 
 fn body_to_vir<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -43,7 +43,7 @@ fn check_fn_decl<'tcx>(
     }
 }
 
-fn check_generics<'tcx>(generics: &'tcx Generics<'tcx>) -> Result<(), VirErr> {
+pub(crate) fn check_generics<'tcx>(generics: &'tcx Generics<'tcx>) -> Result<(), VirErr> {
     match generics {
         Generics { params, where_clause, span: _ } => {
             unsupported_unless!(params.len() == 0, "generics");
@@ -56,7 +56,7 @@ fn check_generics<'tcx>(generics: &'tcx Generics<'tcx>) -> Result<(), VirErr> {
 pub(crate) fn check_item_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
     krate: &'tcx Crate<'tcx>,
-    vir: &mut Vec<Function>,
+    vir: &mut KrateX,
     id: Ident,
     attrs: &[Attribute],
     sig: &'tcx FnSig<'tcx>,
@@ -104,13 +104,13 @@ pub(crate) fn check_item_fn<'tcx>(
     let params = Rc::new(vir_params);
     let function =
         spanned_new(sig.span, FunctionX { name, mode, fuel, params, ret, body: Some(vir_body) });
-    vir.push(function);
+    vir.functions.push(function);
     Ok(())
 }
 
 pub(crate) fn check_foreign_item_fn<'tcx>(
     tcx: TyCtxt<'tcx>,
-    vir: &mut Vec<Function>,
+    vir: &mut KrateX,
     id: Ident,
     span: Span,
     attrs: &[Attribute],
@@ -132,6 +132,6 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
     let name = Rc::new(ident_to_var(&id));
     let params = Rc::new(vir_params);
     let function = spanned_new(span, FunctionX { name, fuel, mode, params, ret, body: None });
-    vir.push(function);
+    vir.functions.push(function);
     Ok(())
 }

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -92,7 +92,7 @@ pub type Fields = Binders<Typ>;
 pub type Variant = Binder<Fields>;
 pub type Variants = Binders<Fields>;
 pub type Datatype = Rc<Spanned<Binder<Variants>>>;
-pub type Datatypes = Binders<Variants>;
+pub type Datatypes = Vec<Rc<Spanned<Binder<Variants>>>>;
 
 pub type Krate = Rc<KrateX>;
 #[derive(Debug, Default)]

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -12,10 +12,11 @@ pub enum Mode {
     Exec,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum Typ {
     Bool,
     Int,
+    Path(Vec<Ident>),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -84,4 +85,18 @@ pub struct FunctionX {
     pub body: Option<Expr>,
 }
 
-pub type Krate = Rc<Vec<Function>>;
+pub use air::ast::Binder;
+pub use air::ast::Binders;
+pub type Field = Binder<Typ>;
+pub type Fields = Binders<Typ>;
+pub type Variant = Binder<Fields>;
+pub type Variants = Binders<Fields>;
+pub type Datatype = Rc<Spanned<Binder<Variants>>>;
+pub type Datatypes = Binders<Variants>;
+
+pub type Krate = Rc<KrateX>;
+#[derive(Debug, Default)]
+pub struct KrateX {
+    pub functions: Vec<Function>,
+    pub datatypes: Vec<Datatype>,
+}

--- a/verify/vir/src/ast_to_sst.rs
+++ b/verify/vir/src/ast_to_sst.rs
@@ -69,7 +69,7 @@ pub fn stmt_to_stm(ctx: &Ctx, stmt: &Stmt) -> Result<Stm, VirErr> {
         StmtX::Expr(expr) => expr_to_stm(ctx, &expr),
         StmtX::Decl { param, mutable } => Ok(Spanned::new(
             stmt.span.clone(),
-            StmX::Decl { ident: param.name.clone(), typ: param.typ, mutable: *mutable },
+            StmX::Decl { ident: param.name.clone(), typ: param.typ.clone(), mutable: *mutable },
         )),
     }
 }

--- a/verify/vir/src/ast_util.rs
+++ b/verify/vir/src/ast_util.rs
@@ -1,0 +1,1 @@
+pub use air::ast_util::{ident_binder, str_ident};

--- a/verify/vir/src/context.rs
+++ b/verify/vir/src/context.rs
@@ -48,7 +48,7 @@ impl Ctx {
     pub fn new(krate: &Krate) -> Result<Self, VirErr> {
         let mut functions: Vec<Function> = Vec::new();
         let mut func_map: HashMap<Ident, Function> = HashMap::new();
-        for function in krate.iter() {
+        for function in krate.functions.iter() {
             Self::check_no_recursion(&func_map, function)?;
             functions.push(function.clone());
             func_map.insert(function.x.name.clone(), function.clone());

--- a/verify/vir/src/datatype_to_air.rs
+++ b/verify/vir/src/datatype_to_air.rs
@@ -1,0 +1,30 @@
+use crate::sst_to_air::typ_to_air;
+use air::ast::{CommandX, Commands, DeclX};
+use std::rc::Rc;
+
+fn datatype_to_air(datatype: &crate::ast::Datatype) -> air::ast::Datatype {
+    Rc::new(datatype.x.map_a(|variants| {
+        Rc::new(
+            variants
+                .iter()
+                .map(|variant| {
+                    Rc::new(variant.map_a(|fields| {
+                        Rc::new(
+                            fields
+                                .iter()
+                                .map(|field| {
+                                    Rc::new(field.map_a(|typ: &crate::ast::Typ| typ_to_air(typ)))
+                                })
+                                .collect::<Vec<_>>(),
+                        )
+                    }))
+                })
+                .collect::<Vec<_>>(),
+        )
+    }))
+}
+
+pub fn datatypes_to_air(datatypes: &crate::ast::Datatypes) -> Commands {
+    let datatypes = datatypes.iter().map(|datatype| datatype_to_air(datatype)).collect::<Vec<_>>();
+    Rc::new(vec![Rc::new(CommandX::Global(Rc::new(DeclX::Datatypes(Rc::new(datatypes)))))])
+}

--- a/verify/vir/src/lib.rs
+++ b/verify/vir/src/lib.rs
@@ -3,6 +3,7 @@ mod ast_to_sst;
 pub mod ast_util;
 mod ast_visitor;
 pub mod context;
+pub mod datatype_to_air;
 pub mod def;
 pub mod func_to_air;
 mod prelude;

--- a/verify/vir/src/lib.rs
+++ b/verify/vir/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod ast;
 mod ast_to_sst;
+pub mod ast_util;
 mod ast_visitor;
 pub mod context;
 pub mod def;

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -15,7 +15,7 @@ use air::ast_util::{
 };
 use std::rc::Rc;
 
-pub fn typ_to_air(typ: &Typ) -> air::ast::Typ {
+pub(crate) fn typ_to_air(typ: &Typ) -> air::ast::Typ {
     match typ {
         Typ::Int => int_typ(),
         Typ::Bool => bool_typ(),

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -10,8 +10,8 @@ use air::ast::{
     StmtX, Trigger, Triggers,
 };
 use air::ast_util::{
-    bool_typ, ident_apply, ident_binder, ident_var, int_typ, str_apply, str_ident, str_typ,
-    str_var, string_var,
+    bool_typ, ident_apply, ident_binder, ident_typ, ident_var, int_typ, str_apply, str_ident,
+    str_typ, str_var, string_var,
 };
 use std::rc::Rc;
 
@@ -19,6 +19,9 @@ pub fn typ_to_air(typ: &Typ) -> air::ast::Typ {
     match typ {
         Typ::Int => int_typ(),
         Typ::Bool => bool_typ(),
+        Typ::Path(segments) => ident_typ(&Rc::new(
+            segments.iter().map(|x| (**x).as_str()).collect::<Vec<_>>().join("::"),
+        )),
     }
 }
 
@@ -116,7 +119,11 @@ pub fn stm_to_stmts(stm: &Stm, decls: &mut Vec<Decl>) -> Vec<Stmt> {
 
 pub fn stm_to_one_stmt(stm: &Stm, decls: &mut Vec<Decl>) -> Stmt {
     let stmts = stm_to_stmts(stm, decls);
-    if stmts.len() == 1 { stmts[0].clone() } else { Rc::new(StmtX::Block(Rc::new(stmts))) }
+    if stmts.len() == 1 {
+        stmts[0].clone()
+    } else {
+        Rc::new(StmtX::Block(Rc::new(stmts)))
+    }
 }
 
 fn set_fuel(local: &mut Vec<Decl>, hidden: &Vec<Ident>) {


### PR DESCRIPTION
Rust:
```rust
struct Car {
    four_doors: bool,
    passengers: int,

}

enum Vehicle {
    Car(Car),
}
```

Air:
```
;; Datatypes
(declare-datatypes () ((Car (Car::Car (four_doors Bool) (passengers Int))) (Vehicle
   (Vehicle::Car (0 Car))
  )
 )
)
```