### PR TITLE
Add support for accessing adt fields

### DIFF
--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -4,7 +4,6 @@ use builtin::{assert, assume, imply, int};
 struct Car {
     four_doors: bool,
     passengers: int,
-
 }
 
 enum Vehicle {
@@ -13,6 +12,12 @@ enum Vehicle {
 
 fn main() {}
 
-// fn test1(p: int) {
-//     assert((Car { passengers: p }).passengers == p);
-// }
+fn test1() {
+    // assert((Car { passengers: p }).passengers == p);
+}
+
+fn test2(c: Car, p: int) {
+    assume(c.passengers == p);
+    assert(c.passengers == p);
+    assert(c.passengers != p); // FAILS
+}

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -151,7 +151,7 @@ pub fn crate_to_vir<'tcx>(tcx: TyCtxt<'tcx>, krate: &'tcx Crate<'tcx>) -> Result
         check_module(tcx, id, module)?;
     }
     unsupported_unless!(proc_macros.len() == 0, "procedural macros", proc_macros);
-    unsupported_unless!(trait_map.len() == 0, "traits", trait_map);
+    unsupported_unless!(trait_map.iter().all(|(_, v)| v.len() == 0), "traits", trait_map);
     for (id, attr) in attrs {
         check_attr(tcx, id, attr)?;
     }

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -49,6 +49,7 @@ pub enum ExprX {
     Const(Constant),
     Var(Ident),
     Call(Ident, Exprs),
+    Field(Expr, Ident),
     Assume(Expr),
     Assert(Expr),
     Unary(UnaryOp, Expr),

--- a/verify/vir/src/ast_to_sst.rs
+++ b/verify/vir/src/ast_to_sst.rs
@@ -35,6 +35,9 @@ pub(crate) fn expr_to_exp(ctx: &Ctx, expr: &Expr) -> Result<Exp, VirErr> {
             Ok(Spanned::new(expr.span.clone(), bin))
         }
         ExprX::Block(stmts, Some(expr)) if stmts.len() == 0 => expr_to_exp(ctx, expr),
+        ExprX::Field(lhs, name) => {
+            Ok(Spanned::new(expr.span.clone(), ExpX::Field(expr_to_exp(ctx, lhs)?, name.clone())))
+        }
         _ => {
             todo!("{:?}", expr)
         }

--- a/verify/vir/src/ast_visitor.rs
+++ b/verify/vir/src/ast_visitor.rs
@@ -17,6 +17,11 @@ where
             let expr = Spanned::new(expr.span.clone(), ExprX::Call(x.clone(), Rc::new(exprs)));
             f(&expr)
         }
+        ExprX::Field(lhs, name) => {
+            let lhs1 = map_expr_visitor(lhs, f)?;
+            let expr = Spanned::new(expr.span.clone(), ExprX::Field(lhs1, name.clone()));
+            f(&expr)
+        }
         ExprX::Assume(e1) => {
             let expr1 = map_expr_visitor(e1, f)?;
             let expr = Spanned::new(expr.span.clone(), ExprX::Assume(expr1));

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -17,6 +17,7 @@ pub enum ExpX {
     Const(Constant),
     Var(Ident),
     Call(Ident, Exps),
+    Field(Exp, Ident),
     Unary(UnaryOp, Exp),
     Binary(BinaryOp, Exp, Exp),
 }

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -74,6 +74,10 @@ pub(crate) fn exp_to_expr(exp: &Exp) -> Expr {
             };
             Rc::new(expx)
         }
+        ExpX::Field(lhs, name) => {
+            let lh = exp_to_expr(lhs);
+            Rc::new(ExprX::Apply(name.clone(), Rc::new(vec![lh])))
+        }
     }
 }
 


### PR DESCRIPTION
Rust:
```
fn test2(c: Car, p: int) {
    assume(c.passengers == p);
    assert(c.passengers == p);
    assert(c.passengers != p); // FAILS
}
```

Air:
```
;; Function-Def test2
(check-valid
 (declare-const c@ Car)
 (declare-const p@ Int)
 (declare-const q@ Int)
 (axiom fuel_defaults)
 (block
  (assume
   (= (passengers c@) p@)
  )
  (assert
   "rust_verify/example/adts.rs:21:12: 21:29 (#0)"
   (= (passengers c@) p@)
  )
  (assert
   "rust_verify/example/adts.rs:22:12: 22:29 (#0)"
   (not (= (passengers c@) p@))
  )
 )
)
```