### PR TITLE
add support for datatype constructor Struct { fieldname: expr ... }

### DIFF
--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -70,6 +70,15 @@ pub struct BinderX<A: Clone> {
     pub a: A,
 }
 
+impl<A: Clone> BinderX<A> {
+    pub fn map_result<B: Clone, E>(
+        &self,
+        f: impl FnOnce(&A) -> Result<B, E>,
+    ) -> Result<Binder<B>, E> {
+        Ok(Rc::new(BinderX { name: self.name.clone(), a: f(&self.a)? }))
+    }
+}
+
 #[derive(Copy, Clone, Debug)]
 pub enum Quant {
     Forall,

--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -14,12 +14,20 @@ enum Vehicle {
 
 fn main() {}
 
-fn test1() {
-    // assert((Car { passengers: p }).passengers == p);
+fn test1(p: int) {
+    assert((Car { four_doors: true, passengers: p }).passengers == p);
+    assert((Car { passengers: p, four_doors: true }).passengers == p); // fields intentionally out of order
+    assert((Car { four_doors: true, passengers: p }).passengers != p); // FAILS
 }
 
 fn test2(c: Car, p: int) {
     assume(c.passengers == p);
     assert(c.passengers == p);
     assert(c.passengers != p); // FAILS
+}
+
+fn test3(p: int) {
+    let c = Car { passengers: p, four_doors: true };
+    assert(c.passengers == p);
+    assert(!c.four_doors); // FAILS
 }

--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -31,3 +31,7 @@ fn test3(p: int) {
     assert(c.passengers == p);
     assert(!c.four_doors); // FAILS
 }
+
+fn test4(passengers: int) {
+    assert((Car { passengers, four_doors: true }).passengers == passengers);
+}

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -213,9 +213,9 @@ impl Verifier {
             let mut file =
                 File::create(filename).expect(&format!("could not open file {}", filename));
             for datatype in vir_crate.datatypes.iter() {
-                writeln!(&mut file, "datatype {} @ {:?}", datatype.x.name, datatype.span)
+                writeln!(&mut file, "datatype {:?} @ {:?}", datatype.x.path, datatype.span)
                     .expect("cannot write to vir file");
-                writeln!(&mut file, "{:?}", datatype.x.a).expect("cannot write to vir file");
+                writeln!(&mut file, "{:?}", datatype.x.variants).expect("cannot write to vir file");
                 writeln!(&mut file).expect("cannot write to vir file");
             }
             for func in vir_crate.functions.iter() {

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -1,6 +1,8 @@
 use crate::def::Spanned;
-use air::ast::{Constant, Quant};
+use air::ast::Quant;
 use std::rc::Rc;
+
+pub use air::ast::{Binder, Binders};
 
 pub type VirErr = Rc<Spanned<VirErrX>>;
 #[derive(Clone, Debug)]
@@ -80,6 +82,13 @@ pub enum HeaderExprX {
     Invariant(Exprs),
 }
 
+#[derive(Clone, Debug)]
+pub enum Constant {
+    Bool(bool),
+    Nat(Rc<String>),
+    Ctor(Path, Ident, Binders<Expr>),
+}
+
 pub type Expr = Rc<Spanned<ExprX>>;
 pub type Exprs = Rc<Vec<Expr>>;
 #[derive(Debug)]
@@ -133,14 +142,18 @@ pub struct FunctionX {
     pub body: Option<Expr>,
 }
 
-pub use air::ast::Binder;
-pub use air::ast::Binders;
 pub type Field = Binder<(Typ, Mode)>;
 pub type Fields = Binders<(Typ, Mode)>;
 pub type Variant = Binder<Fields>;
 pub type Variants = Binders<Fields>;
-pub type Datatype = Rc<Spanned<Binder<Variants>>>;
-pub type Datatypes = Vec<Rc<Spanned<Binder<Variants>>>>;
+
+#[derive(Debug)]
+pub struct DatatypeX {
+    pub path: Path,
+    pub variants: Variants,
+}
+pub type Datatype = Rc<Spanned<DatatypeX>>;
+pub type Datatypes = Vec<Datatype>;
 
 pub type Krate = Rc<KrateX>;
 #[derive(Debug, Default)]

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -102,6 +102,10 @@ pub fn prefix_ensures(ident: &Ident) -> Ident {
     Rc::new(PREFIX_ENSURES.to_string() + ident)
 }
 
+pub fn variant_ident(adt_name: &str, variant_name: &str) -> Ident {
+    Rc::new(format!("{}{}{}", adt_name, VARIANT_SEPARATOR, variant_name))
+}
+
 pub struct Spanned<X> {
     pub span: Span,
     pub x: X,

--- a/verify/vir/src/func_to_air.rs
+++ b/verify/vir/src/func_to_air.rs
@@ -65,7 +65,7 @@ fn func_body_to_air(
 
     // (axiom (=> (fuel_bool fuel%f) (forall (...) (= (f ...) ...)))
     let body_exp = crate::ast_to_sst::expr_to_exp(&ctx, &body)?;
-    let body_expr = exp_to_expr(&body_exp);
+    let body_expr = exp_to_expr(&ctx, &body_exp);
     let e_forall = func_def_quant(
         &suffix_global_id(&function.x.name),
         &function.x.typ_params,
@@ -103,7 +103,7 @@ pub fn req_ens_to_air(
         }
         for e in specs.iter() {
             let exp = crate::ast_to_sst::expr_to_exp(ctx, e)?;
-            let expr = exp_to_expr(&exp);
+            let expr = exp_to_expr(ctx, &exp);
             let loc_expr = match msg {
                 None => expr,
                 Some(msg) => {

--- a/verify/vir/src/modes.rs
+++ b/verify/vir/src/modes.rs
@@ -1,5 +1,6 @@
 use crate::ast::{Datatype, Expr, ExprX, Function, Ident, Krate, Mode, Stmt, StmtX, VirErr};
 use crate::ast_util::err_string;
+use crate::sst_to_air::path_to_air_ident;
 use std::collections::HashMap;
 
 // Exec <= Proof <= Spec
@@ -66,7 +67,7 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
         ExprX::Field { lhs, datatype_name, field_name } => {
             let lhs_mode = check_expr(typing, outer_mode, lhs)?;
             let datatype = &typing.datatypes[datatype_name].clone();
-            let variants = &datatype.x.a;
+            let variants = &datatype.x.variants;
             assert_eq!(variants.len(), 1);
             let fields = &variants[0].a;
             for field in fields.iter() {
@@ -208,7 +209,7 @@ pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
         funs.insert(function.x.name.clone(), function.clone());
     }
     for datatype in krate.datatypes.iter() {
-        datatypes.insert(datatype.x.name.clone(), datatype.clone());
+        datatypes.insert(path_to_air_ident(&datatype.x.path.clone()), datatype.clone());
     }
     let mut typing = Typing { funs, datatypes, vars: HashMap::new() };
     for function in krate.functions.iter() {

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -5,9 +5,9 @@ Whereas ast supports statements inside expressions,
 sst expressions cannot contain statments.
 */
 
-use crate::ast::{BinaryOp, Typ, Typs, UnaryOp, UnaryOpr};
+use crate::ast::{BinaryOp, Path, Typ, Typs, UnaryOp, UnaryOpr};
 use crate::def::Spanned;
-use air::ast::{Binders, Constant, Ident, Quant};
+use air::ast::{Binders, Ident, Quant};
 use std::rc::Rc;
 
 pub type Trig = Exps;
@@ -18,6 +18,13 @@ pub type Bnd = Rc<Spanned<BndX>>;
 pub enum BndX {
     Let(Binders<Exp>),
     Quant(Quant, Binders<Typ>, Trigs),
+}
+
+#[derive(Clone, Debug)]
+pub enum Constant {
+    Bool(bool),
+    Nat(Rc<String>),
+    Ctor(Path, Ident, Binders<Exp>),
 }
 
 pub type Exp = Rc<Spanned<ExpX>>;

--- a/verify/vir/src/triggers_auto.rs
+++ b/verify/vir/src/triggers_auto.rs
@@ -170,7 +170,18 @@ fn make_score(term: &Term, depth: u64) -> Score {
 fn gather_terms(ctxt: &mut Ctxt, exp: &Exp, depth: u64) -> (bool, Term) {
     let (is_pure, term) = match &exp.x {
         ExpX::Const(c) => {
-            return (true, Rc::new(TermX::App(App::Const(c.clone()), Rc::new(vec![]))));
+            let term = match c {
+                crate::sst::Constant::Bool(b) => {
+                    Rc::new(TermX::App(App::Const(Constant::Bool(*b)), Rc::new(vec![])))
+                }
+                crate::sst::Constant::Nat(n) => {
+                    Rc::new(TermX::App(App::Const(Constant::Nat(n.clone())), Rc::new(vec![])))
+                }
+                crate::sst::Constant::Ctor(path, variant, fields) => {
+                    todo!("gather_terms for datatype ctor")
+                }
+            };
+            return (true, term);
         }
         ExpX::Var(x) => {
             return (true, Rc::new(TermX::Var(x.clone())));


### PR DESCRIPTION
Rust:
```rust
// ...

struct Car {
    four_doors: bool,
    passengers: int,
}

fn test1(p: int) {
    assert((Car { four_doors: true, passengers: p }).passengers == p);
    assert((Car { passengers: p, four_doors: true }).passengers == p); // fields intentionally out of order
    assert((Car { four_doors: true, passengers: p }).passengers != p); // FAILS
}

fn test3(p: int) {
    let c = Car { passengers: p, four_doors: true };
    assert(c.passengers == p);
    assert(!c.four_doors); // FAILS
}
```

Air:
```
;; Function-Def test1
(check-valid
 (declare-const p@ Int)
 (axiom fuel_defaults)
 (block
  (block
   (assert
    "rust_verify/example/adts.rs:18:5: 18:70 (#0)"
    (req%assert (= (passengers (Car::Car true p@)) p@))
   )
   (assume
    (ens%assert (= (passengers (Car::Car true p@)) p@))
  ))
  (block
   (assert
    "rust_verify/example/adts.rs:19:5: 19:70 (#0)"
    (req%assert (= (passengers (Car::Car true p@)) p@))
   )
   (assume
    (ens%assert (= (passengers (Car::Car true p@)) p@))
  ))
  (block
   (assert
    "rust_verify/example/adts.rs:20:5: 20:70 (#0)"
    (req%assert (not (= (passengers (Car::Car true p@)) p@)))
   )
   (assume
    (ens%assert (not (= (passengers (Car::Car true p@)) p@)))
))))

;; Function-Def test3
(check-valid
 (declare-const p@ Int)
 (axiom fuel_defaults)
 (declare-const c@ Car)
 (block
  (assume
   (= c@ (Car::Car true p@))
  )
  (block
   (assert
    "rust_verify/example/adts.rs:31:5: 31:30 (#0)"
    (req%assert (= (passengers c@) p@))
   )
   (assume
    (ens%assert (= (passengers c@) p@))
  ))
  (block
   (assert
    "rust_verify/example/adts.rs:32:5: 32:26 (#0)"
    (req%assert (not (four_doors c@)))
   )
   (assume
    (ens%assert (not (four_doors c@)))
))))
```