### PR TITLE
Support enum datatype ctors

### DIFF
--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -10,28 +10,38 @@ struct Car {
 
 enum Vehicle {
     Car(Car),
+    Train(bool),
 }
 
 fn main() {}
 
-fn test1(p: int) {
+fn test_struct_1(p: int) {
     assert((Car { four_doors: true, passengers: p }).passengers == p);
     assert((Car { passengers: p, four_doors: true }).passengers == p); // fields intentionally out of order
     assert((Car { four_doors: true, passengers: p }).passengers != p); // FAILS
 }
 
-fn test2(c: Car, p: int) {
+fn test_struct_2(c: Car, p: int) {
     assume(c.passengers == p);
     assert(c.passengers == p);
     assert(c.passengers != p); // FAILS
 }
 
-fn test3(p: int) {
+fn test_struct_3(p: int) {
     let c = Car { passengers: p, four_doors: true };
     assert(c.passengers == p);
     assert(!c.four_doors); // FAILS
 }
 
-fn test4(passengers: int) {
+fn test_struct_4(passengers: int) {
     assert((Car { passengers, four_doors: true }).passengers == passengers);
 }
+
+fn test_enum_1(passengers: int) {
+    let t = Vehicle::Train(true);
+    let c1 = Vehicle::Car(Car { passengers, four_doors: true });
+    let c2 = Vehicle::Car(Car { passengers, four_doors: false });
+    // assert(t != c1);
+    // assert(c1 != c2);
+}
+

--- a/verify/rust_verify/src/rust_to_vir_adts.rs
+++ b/verify/rust_verify/src/rust_to_vir_adts.rs
@@ -9,7 +9,7 @@ use rustc_span::Span;
 use std::rc::Rc;
 use vir::ast::{DatatypeX, Ident, KrateX, Mode, Variant, VirErr};
 use vir::ast_util::{ident_binder, str_ident};
-use vir::def::variant_ident;
+use vir::def::{variant_field_ident, variant_ident, variant_positional_field_ident};
 
 fn check_variant_data<'tcx>(
     tcx: TyCtxt<'tcx>,
@@ -27,7 +27,7 @@ fn check_variant_data<'tcx>(
                         .iter()
                         .map(|field| {
                             ident_binder(
-                                &str_ident(&field.ident.as_str()),
+                                &variant_field_ident(name, &field.ident.as_str()),
                                 &(
                                     ty_to_vir(tcx, field.ty),
                                     get_mode(Mode::Exec, tcx.hir().attrs(field.hir_id)),
@@ -40,9 +40,10 @@ fn check_variant_data<'tcx>(
             VariantData::Tuple(fields, _variant_id) => Rc::new(
                 fields
                     .iter()
-                    .map(|field| {
+                    .enumerate()
+                    .map(|(i, field)| {
                         ident_binder(
-                            &str_ident(&field.ident.as_str()),
+                            &variant_positional_field_ident(name, i),
                             &(
                                 ty_to_vir(tcx, field.ty),
                                 get_mode(Mode::Exec, tcx.hir().attrs(field.hir_id)),

--- a/verify/rust_verify/src/rust_to_vir_expr.rs
+++ b/verify/rust_verify/src/rust_to_vir_expr.rs
@@ -22,8 +22,8 @@ use vir::ast::{
     BinaryOp, Constant, ExprX, HeaderExpr, HeaderExprX, IntRange, ParamX, StmtX, Stmts, Typ, TypX,
     UnaryOp, UnaryOpr, VirErr,
 };
-use vir::ast_util::{ident_binder, str_ident};
-use vir::def::{variant_ident, Spanned};
+use vir::ast_util::ident_binder;
+use vir::def::{variant_field_ident, variant_ident, variant_positional_field_ident, Spanned};
 
 pub(crate) fn pat_to_var<'tcx>(pat: &Pat) -> String {
     let Pat { hir_id: _, kind, span: _, default_binding_modes } = pat;
@@ -154,6 +154,181 @@ pub(crate) fn expr_to_vir<'tcx>(
     Ok(vir_expr)
 }
 
+fn fn_call_to_vir<'tcx>(
+    ctxt: &Ctxt<'tcx>,
+    expr: &Expr<'tcx>,
+    fun: &'tcx Expr<'tcx>,
+    args_slice: &'tcx [Expr<'tcx>],
+) -> Result<vir::ast::Expr, VirErr> {
+    let mut args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
+    let f = expr_to_function(fun);
+    let is_admit = hack_check_def_name(ctxt.tcx, f, "builtin", "admit");
+    let is_requires = hack_check_def_name(ctxt.tcx, f, "builtin", "requires");
+    let is_ensures = hack_check_def_name(ctxt.tcx, f, "builtin", "ensures");
+    let is_invariant = hack_check_def_name(ctxt.tcx, f, "builtin", "invariant");
+    let is_forall = hack_check_def_name(ctxt.tcx, f, "builtin", "forall");
+    let is_exists = hack_check_def_name(ctxt.tcx, f, "builtin", "exists");
+    let is_hide = hack_check_def_name(ctxt.tcx, f, "builtin", "hide");
+    let is_reveal = hack_check_def_name(ctxt.tcx, f, "builtin", "reveal");
+    let is_implies = hack_check_def_name(ctxt.tcx, f, "builtin", "imply");
+    let is_eq = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialEq::eq");
+    let is_ne = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialEq::ne");
+    let is_le = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialOrd::le");
+    let is_ge = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialOrd::ge");
+    let is_lt = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialOrd::lt");
+    let is_gt = hack_check_def_name(ctxt.tcx, f, "core", "cmp::PartialOrd::gt");
+    let is_add = hack_check_def_name(ctxt.tcx, f, "core", "ops::arith::Add::add");
+    let is_sub = hack_check_def_name(ctxt.tcx, f, "core", "ops::arith::Sub::sub");
+    let is_mul = hack_check_def_name(ctxt.tcx, f, "core", "ops::arith::Mul::mul");
+    let is_cmp = is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
+    let is_arith_binary = is_add || is_sub || is_mul;
+
+    let len = args.len();
+    if is_requires {
+        unsupported_err_unless!(len == 1, expr.span, "expected requires", &args);
+        args = extract_array(args[0]);
+        for arg in &args {
+            if !matches!(ctxt.types.node_type(arg.hir_id).kind(), TyKind::Bool) {
+                return err_span_str(arg.span, "requires needs a bool expression");
+            }
+        }
+    }
+    if is_ensures {
+        unsupported_err_unless!(len == 1, expr.span, "expected ensures", &args);
+        let header = extract_ensures(ctxt, args[0])?;
+        let expr = spanned_new(args[0].span, ExprX::Header(header));
+        return Ok(expr);
+    }
+    if is_invariant {
+        unsupported_err_unless!(len == 1, expr.span, "expected invariant", &args);
+        args = extract_array(args[0]);
+        for arg in &args {
+            if !matches!(ctxt.types.node_type(arg.hir_id).kind(), TyKind::Bool) {
+                return err_span_str(arg.span, "invariant needs a bool expression");
+            }
+        }
+    }
+    if is_forall || is_exists {
+        unsupported_err_unless!(len == 1, expr.span, "expected forall/exists", &args);
+        let quant = if is_forall { Quant::Forall } else { Quant::Exists };
+        return extract_quant(ctxt, expr.span, quant, args[0]);
+    }
+
+    let mut vir_args = vec_map_result(&args, |arg| expr_to_vir(ctxt, arg))?;
+
+    if is_requires {
+        let header = Rc::new(HeaderExprX::Requires(Rc::new(vir_args)));
+        Ok(spanned_new(expr.span, ExprX::Header(header)))
+    } else if is_invariant {
+        let header = Rc::new(HeaderExprX::Invariant(Rc::new(vir_args)));
+        Ok(spanned_new(expr.span, ExprX::Header(header)))
+    } else if is_admit {
+        unsupported_err_unless!(len == 0, expr.span, "expected admit", args);
+        Ok(spanned_new(expr.span, ExprX::Admit))
+    } else if is_hide || is_reveal {
+        unsupported_err_unless!(len == 1, expr.span, "expected hide/reveal", args);
+        let arg = vir_args[0].clone();
+        if let ExprX::Var(x) = &arg.x {
+            if is_hide {
+                let header = Rc::new(HeaderExprX::Hide(x.clone()));
+                Ok(spanned_new(expr.span, ExprX::Header(header)))
+            } else {
+                Ok(spanned_new(expr.span, ExprX::Fuel(x.clone(), 1)))
+            }
+        } else {
+            err_span_str(expr.span, "hide/reveal: expected identifier")
+        }
+    } else if is_cmp || is_arith_binary || is_implies {
+        unsupported_err_unless!(len == 2, expr.span, "expected binary op", args);
+        let lhs = vir_args[0].clone();
+        let rhs = vir_args[1].clone();
+        let vop = if is_eq {
+            BinaryOp::Eq
+        } else if is_ne {
+            BinaryOp::Ne
+        } else if is_le {
+            BinaryOp::Le
+        } else if is_ge {
+            BinaryOp::Ge
+        } else if is_lt {
+            BinaryOp::Lt
+        } else if is_gt {
+            BinaryOp::Gt
+        } else if is_add {
+            BinaryOp::Add
+        } else if is_sub {
+            BinaryOp::Sub
+        } else if is_mul {
+            BinaryOp::Mul
+        } else if is_implies {
+            BinaryOp::Implies
+        } else {
+            panic!("internal error")
+        };
+        let e = spanned_new(expr.span, ExprX::Binary(vop, lhs, rhs));
+        let ty = ctxt.types.node_type(expr.hir_id);
+        if is_arith_binary { Ok(mk_ty_clip(ty, &e)) } else { Ok(e) }
+    } else {
+        let fun_ty = ctxt.types.node_type(fun.hir_id);
+        let (param_typs, ret_typ) = match fun_ty.kind() {
+            TyKind::FnDef(def_id, _substs) => match ctxt.tcx.fn_sig(*def_id).no_bound_vars() {
+                None => unsupported_err!(expr.span, format!("found bound vars in function"), expr),
+                Some(f) => {
+                    let params: Vec<Typ> =
+                        f.inputs().iter().map(|t| mid_ty_to_vir(ctxt.tcx, *t)).collect();
+                    let ret = mid_ty_to_vir_opt(ctxt.tcx, f.output());
+                    (params, ret)
+                }
+            },
+            _ => unsupported_err!(expr.span, format!("call to non-FnDef function"), expr),
+        };
+        // box arguments where necessary
+        let arg_typs = vec_map(&args, |arg| typ_of_node(ctxt, &arg.hir_id));
+        assert_eq!(vir_args.len(), param_typs.len());
+        assert_eq!(vir_args.len(), arg_typs.len());
+        for i in 0..vir_args.len() {
+            match (&*param_typs[i], &*arg_typs[i]) {
+                (TypX::TypParam(_), TypX::TypParam(_)) => {} // already boxed
+                (TypX::TypParam(_), _) => {
+                    let arg = &vir_args[i];
+                    let arg_x = ExprX::UnaryOpr(UnaryOpr::Box(arg_typs[i].clone()), arg.clone());
+                    vir_args[i] = Spanned::new(arg.span.clone(), arg_x);
+                }
+                _ => {}
+            }
+        }
+        // type arguments
+        let mut typ_args: Vec<Typ> = Vec::new();
+        for typ_arg in ctxt.types.node_substs(fun.hir_id) {
+            match typ_arg.unpack() {
+                GenericArgKind::Type(ty) => {
+                    typ_args.push(mid_ty_to_vir(ctxt.tcx, ty));
+                }
+                _ => unsupported_err!(expr.span, format!("lifetime/const type arguments"), expr),
+            }
+        }
+        // make call
+        let name = hack_get_def_name(ctxt.tcx, f); // TODO: proper handling of paths
+        let mut call = spanned_new(
+            expr.span,
+            ExprX::Call(Rc::new(name), Rc::new(typ_args), Rc::new(vir_args)),
+        );
+        // unbox result if necessary
+        if let Some(ret_typ) = ret_typ {
+            let expr_typ = typ_of_node(ctxt, &expr.hir_id);
+            match (&*ret_typ, &*expr_typ) {
+                (TypX::TypParam(_), TypX::TypParam(_)) => {} // already boxed
+                (TypX::TypParam(_), _) => {
+                    let call_x = ExprX::UnaryOpr(UnaryOpr::Unbox(expr_typ.clone()), call);
+                    call = spanned_new(expr.span, call_x);
+                }
+                _ => {}
+            }
+        }
+        Ok(call)
+    }
+}
+
 pub(crate) fn expr_to_vir_inner<'tcx>(
     ctxt: &Ctxt<'tcx>,
     expr: &Expr<'tcx>,
@@ -172,186 +347,60 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             Ok(spanned_new(expr.span, ExprX::Block(vir_stmts, vir_expr)))
         }
         ExprKind::Call(fun, args_slice) => {
-            let mut args: Vec<&'tcx Expr<'tcx>> = args_slice.iter().collect();
-            let f = expr_to_function(fun);
-            let is_admit = hack_check_def_name(tcx, f, "builtin", "admit");
-            let is_requires = hack_check_def_name(tcx, f, "builtin", "requires");
-            let is_ensures = hack_check_def_name(tcx, f, "builtin", "ensures");
-            let is_invariant = hack_check_def_name(tcx, f, "builtin", "invariant");
-            let is_forall = hack_check_def_name(tcx, f, "builtin", "forall");
-            let is_exists = hack_check_def_name(tcx, f, "builtin", "exists");
-            let is_hide = hack_check_def_name(tcx, f, "builtin", "hide");
-            let is_reveal = hack_check_def_name(tcx, f, "builtin", "reveal");
-            let is_implies = hack_check_def_name(tcx, f, "builtin", "imply");
-            let is_eq = hack_check_def_name(tcx, f, "core", "cmp::PartialEq::eq");
-            let is_ne = hack_check_def_name(tcx, f, "core", "cmp::PartialEq::ne");
-            let is_le = hack_check_def_name(tcx, f, "core", "cmp::PartialOrd::le");
-            let is_ge = hack_check_def_name(tcx, f, "core", "cmp::PartialOrd::ge");
-            let is_lt = hack_check_def_name(tcx, f, "core", "cmp::PartialOrd::lt");
-            let is_gt = hack_check_def_name(tcx, f, "core", "cmp::PartialOrd::gt");
-            let is_add = hack_check_def_name(tcx, f, "core", "ops::arith::Add::add");
-            let is_sub = hack_check_def_name(tcx, f, "core", "ops::arith::Sub::sub");
-            let is_mul = hack_check_def_name(tcx, f, "core", "ops::arith::Mul::mul");
-            let is_cmp = is_eq || is_ne || is_le || is_ge || is_lt || is_gt;
-            let is_arith_binary = is_add || is_sub || is_mul;
-
-            let len = args.len();
-            if is_requires {
-                unsupported_err_unless!(len == 1, expr.span, "expected requires", &args);
-                args = extract_array(args[0]);
-                for arg in &args {
-                    if !matches!(tc.node_type(arg.hir_id).kind(), TyKind::Bool) {
-                        return err_span_str(arg.span, "requires needs a bool expression");
-                    }
-                }
-            }
-            if is_ensures {
-                unsupported_err_unless!(len == 1, expr.span, "expected ensures", &args);
-                let header = extract_ensures(ctxt, args[0])?;
-                let expr = spanned_new(args[0].span, ExprX::Header(header));
-                return Ok(expr);
-            }
-            if is_invariant {
-                unsupported_err_unless!(len == 1, expr.span, "expected invariant", &args);
-                args = extract_array(args[0]);
-                for arg in &args {
-                    if !matches!(tc.node_type(arg.hir_id).kind(), TyKind::Bool) {
-                        return err_span_str(arg.span, "invariant needs a bool expression");
-                    }
-                }
-            }
-            if is_forall || is_exists {
-                unsupported_err_unless!(len == 1, expr.span, "expected forall/exists", &args);
-                let quant = if is_forall { Quant::Forall } else { Quant::Exists };
-                return extract_quant(ctxt, expr.span, quant, args[0]);
-            }
-
-            let mut vir_args = vec_map_result(&args, |arg| expr_to_vir(ctxt, arg))?;
-
-            if is_requires {
-                let header = Rc::new(HeaderExprX::Requires(Rc::new(vir_args)));
-                Ok(spanned_new(expr.span, ExprX::Header(header)))
-            } else if is_invariant {
-                let header = Rc::new(HeaderExprX::Invariant(Rc::new(vir_args)));
-                Ok(spanned_new(expr.span, ExprX::Header(header)))
-            } else if is_admit {
-                unsupported_err_unless!(len == 0, expr.span, "expected admit", args);
-                Ok(spanned_new(expr.span, ExprX::Admit))
-            } else if is_hide || is_reveal {
-                unsupported_err_unless!(len == 1, expr.span, "expected hide/reveal", args);
-                let arg = vir_args[0].clone();
-                if let ExprX::Var(x) = &arg.x {
-                    if is_hide {
-                        let header = Rc::new(HeaderExprX::Hide(x.clone()));
-                        Ok(spanned_new(expr.span, ExprX::Header(header)))
-                    } else {
-                        Ok(spanned_new(expr.span, ExprX::Fuel(x.clone(), 1)))
-                    }
-                } else {
-                    err_span_str(expr.span, "hide/reveal: expected identifier")
-                }
-            } else if is_cmp || is_arith_binary || is_implies {
-                unsupported_err_unless!(len == 2, expr.span, "expected binary op", args);
-                let lhs = vir_args[0].clone();
-                let rhs = vir_args[1].clone();
-                let vop = if is_eq {
-                    BinaryOp::Eq
-                } else if is_ne {
-                    BinaryOp::Ne
-                } else if is_le {
-                    BinaryOp::Le
-                } else if is_ge {
-                    BinaryOp::Ge
-                } else if is_lt {
-                    BinaryOp::Lt
-                } else if is_gt {
-                    BinaryOp::Gt
-                } else if is_add {
-                    BinaryOp::Add
-                } else if is_sub {
-                    BinaryOp::Sub
-                } else if is_mul {
-                    BinaryOp::Mul
-                } else if is_implies {
-                    BinaryOp::Implies
-                } else {
-                    panic!("internal error")
-                };
-                let e = spanned_new(expr.span, ExprX::Binary(vop, lhs, rhs));
-                let ty = tc.node_type(expr.hir_id);
-                if is_arith_binary { Ok(mk_ty_clip(ty, &e)) } else { Ok(e) }
-            } else {
-                let fun_ty = ctxt.types.node_type(fun.hir_id);
-                let (param_typs, ret_typ) = match fun_ty.kind() {
-                    TyKind::FnDef(def_id, _substs) => {
-                        match ctxt.tcx.fn_sig(*def_id).no_bound_vars() {
-                            None => unsupported_err!(
-                                expr.span,
-                                format!("found bound vars in function"),
-                                expr
-                            ),
-                            Some(f) => {
-                                let params: Vec<Typ> = f
-                                    .inputs()
-                                    .iter()
-                                    .map(|t| mid_ty_to_vir(ctxt.tcx, *t))
-                                    .collect();
-                                let ret = mid_ty_to_vir_opt(ctxt.tcx, f.output());
-                                (params, ret)
-                            }
-                        }
-                    }
-                    _ => unsupported_err!(expr.span, format!("call to non-FnDef function"), expr),
-                };
-                // box arguments where necessary
-                let arg_typs = vec_map(&args, |arg| typ_of_node(ctxt, &arg.hir_id));
-                assert_eq!(vir_args.len(), param_typs.len());
-                assert_eq!(vir_args.len(), arg_typs.len());
-                for i in 0..vir_args.len() {
-                    match (&*param_typs[i], &*arg_typs[i]) {
-                        (TypX::TypParam(_), TypX::TypParam(_)) => {} // already boxed
-                        (TypX::TypParam(_), _) => {
-                            let arg = &vir_args[i];
-                            let arg_x =
-                                ExprX::UnaryOpr(UnaryOpr::Box(arg_typs[i].clone()), arg.clone());
-                            vir_args[i] = Spanned::new(arg.span.clone(), arg_x);
-                        }
-                        _ => {}
-                    }
-                }
-                // type arguments
-                let mut typ_args: Vec<Typ> = Vec::new();
-                for typ_arg in ctxt.types.node_substs(fun.hir_id) {
-                    match typ_arg.unpack() {
-                        GenericArgKind::Type(ty) => {
-                            typ_args.push(mid_ty_to_vir(ctxt.tcx, ty));
-                        }
-                        _ => unsupported_err!(
+            match fun.kind {
+                // a tuple-style datatype constructor
+                ExprKind::Path(QPath::Resolved(
+                    None,
+                    rustc_hir::Path { res: Res::Def(ctor @ DefKind::Ctor(_, _), def_id), .. },
+                )) => {
+                    if let DefKind::Ctor(ctor_of, ctor_kind) = ctor {
+                        unsupported_unless!(
+                            ctor_of == &rustc_hir::def::CtorOf::Variant,
+                            "non_variant_ctor_in_call_expr",
+                            fun
+                        );
+                        unsupported_unless!(
+                            ctor_kind == &rustc_hir::def::CtorKind::Fn,
+                            "non_fn_ctor_in_call_expr",
+                            fun
+                        );
+                        let (vir_path, variant) = {
+                            let mut vir_path = def_id_to_vir_path(tcx, *def_id);
+                            Rc::get_mut(&mut vir_path).unwrap().pop(); // remove constructor
+                            let variant = Rc::get_mut(&mut vir_path)
+                                .unwrap()
+                                .pop()
+                                .expect("invalid path in datatype ctor");
+                            (vir_path, variant)
+                        };
+                        let name = vir_path.last().expect("invalid path in datatype ctor");
+                        let variant_name = variant_ident(name.as_str(), variant.as_str());
+                        let vir_fields = Rc::new(
+                            args_slice
+                                .iter()
+                                .enumerate()
+                                .map(|(i, e)| -> Result<_, VirErr> {
+                                    Ok(ident_binder(
+                                        &variant_positional_field_ident(&variant_name, i),
+                                        &expr_to_vir(ctxt, e)?,
+                                    ))
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
+                        );
+                        Ok(spanned_new(
                             expr.span,
-                            format!("lifetime/const type arguments"),
-                            expr
-                        ),
+                            ExprX::Const(Constant::Ctor(vir_path, variant_name, vir_fields)),
+                        ))
+                    } else {
+                        unreachable!()
                     }
                 }
-                // make call
-                let name = hack_get_def_name(tcx, f); // TODO: proper handling of paths
-                let mut call = spanned_new(
-                    expr.span,
-                    ExprX::Call(Rc::new(name), Rc::new(typ_args), Rc::new(vir_args)),
-                );
-                // unbox result if necessary
-                if let Some(ret_typ) = ret_typ {
-                    let expr_typ = typ_of_node(ctxt, &expr.hir_id);
-                    match (&*ret_typ, &*expr_typ) {
-                        (TypX::TypParam(_), TypX::TypParam(_)) => {} // already boxed
-                        (TypX::TypParam(_), _) => {
-                            let call_x = ExprX::UnaryOpr(UnaryOpr::Unbox(expr_typ.clone()), call);
-                            call = spanned_new(expr.span, call_x);
-                        }
-                        _ => {}
-                    }
-                }
-                Ok(call)
+                // a function
+                ExprKind::Path(QPath::Resolved(
+                    None,
+                    rustc_hir::Path { res: Res::Def(DefKind::Fn, _), .. },
+                )) => fn_call_to_vir(ctxt, expr, fun, args_slice),
+                _ => unsupported!("fun_kind_not_ctor_or_fn"),
             }
         }
         ExprKind::Lit(lit) => match lit.node {
@@ -444,7 +493,9 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                     "field_of_adt_with_multiple_variants",
                     expr
                 );
-                (Rc::new(hack_get_def_name(tcx, adt_def.did)), str_ident(&name.as_str()))
+                let datatype_name = hack_get_def_name(tcx, adt_def.did);
+                let variant_name = variant_ident(datatype_name.as_str(), datatype_name.as_str());
+                (Rc::new(datatype_name), variant_field_ident(&variant_name, &name.as_str()))
             } else {
                 unsupported_err!(expr.span, "field_of_non_adt", expr)
             };
@@ -532,7 +583,10 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
                 fields
                     .iter()
                     .map(|f| -> Result<_, VirErr> {
-                        Ok(ident_binder(&str_ident(&f.ident.as_str()), &expr_to_vir(ctxt, f.expr)?))
+                        Ok(ident_binder(
+                            &variant_field_ident(&variant_name, &f.ident.as_str()),
+                            &expr_to_vir(ctxt, f.expr)?,
+                        ))
                     })
                     .collect::<Result<Vec<_>, _>>()?,
             );

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -65,6 +65,7 @@ pub const TYPE_ID_UINT: &str = "UINT";
 pub const TYPE_ID_SINT: &str = "SINT";
 pub const PREFIX_TYPE_ID: &str = "TYPE%";
 pub const HAS_TYPE: &str = "has_type";
+pub const VARIANT_FIELD_SEPARATOR: &str = "/";
 
 pub fn suffix_global_id(ident: &Ident) -> Ident {
     Rc::new(ident.to_string() + SUFFIX_GLOBAL)
@@ -104,6 +105,15 @@ pub fn prefix_ensures(ident: &Ident) -> Ident {
 
 pub fn variant_ident(adt_name: &str, variant_name: &str) -> Ident {
     Rc::new(format!("{}{}{}", adt_name, VARIANT_SEPARATOR, variant_name))
+}
+
+pub fn variant_field_ident(variant_ident: &Ident, name: &str) -> Ident {
+    Rc::new(format!("{}{}{}", variant_ident.as_str(), VARIANT_FIELD_SEPARATOR, name))
+}
+
+#[inline(always)]
+pub fn variant_positional_field_ident(variant_ident: &Ident, idx: usize) -> Ident {
+    variant_field_ident(variant_ident, format!("{}", idx).as_str())
 }
 
 pub struct Spanned<X> {

--- a/verify/vir/src/modes.rs
+++ b/verify/vir/src/modes.rs
@@ -70,12 +70,10 @@ fn check_expr(typing: &mut Typing, outer_mode: Mode, expr: &Expr) -> Result<Mode
             let variants = &datatype.x.variants;
             assert_eq!(variants.len(), 1);
             let fields = &variants[0].a;
-            for field in fields.iter() {
-                if field.name == *field_name {
-                    return Ok(mode_join(lhs_mode, field.a.1));
-                }
+            match fields.iter().find(|field| field.name == *field_name) {
+                Some(field) => Ok(mode_join(lhs_mode, field.a.1)),
+                None => panic!("internal error: missing field {}", &field_name),
             }
-            panic!("internal error: missing field {}", &field_name)
         }
         ExprX::Unary(_, e1) => check_expr(typing, outer_mode, e1),
         ExprX::UnaryOpr(_, e1) => check_expr(typing, outer_mode, e1),

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -105,7 +105,7 @@ pub(crate) fn ctor_to_apply<'a>(
 ) -> (Ident, impl Iterator<Item = &'a Rc<BinderX<Rc<Spanned<ExpX>>>>>) {
     let fields = &ctx.datatypes[path]
         .iter()
-        .find(|variant| variant.name == variant.name)
+        .find(|v| &v.name == variant)
         .expect(format!("couldn't find datatype variant {} in ctor", variant).as_str())
         .a;
     (


### PR DESCRIPTION
Rust:
```
fn test_enum_1(passengers: int) {
    let t = Vehicle::Train(true);
    let c1 = Vehicle::Car(Car { passengers, four_doors: true });
    let c2 = Vehicle::Car(Car { passengers, four_doors: false });
}
```

Air:
```
;; Function-Def test_enum_1
(check-valid
 (declare-const passengers@ Int)
 (axiom fuel_defaults)
 (declare-const t@ Vehicle)
 (declare-const c1@ Vehicle)
 (declare-const c2@ Vehicle)
 (block
  (assume
   (= t@ (Vehicle/Train true))
  )
  (assume
   (= c1@ (Vehicle/Car (Car/Car true passengers@)))
  )
  (assume
   (= c2@ (Vehicle/Car (Car/Car false passengers@)))
)))
```