### PR TITLE
Add support for default equality (#[derive(PartialEq, Eq)]) of structs and enums

### DIFF
--- a/verify/rust_verify/example/adts.rs
+++ b/verify/rust_verify/example/adts.rs
@@ -3,11 +3,13 @@ use builtin::*;
 mod pervasive;
 use pervasive::*;
 
+#[derive(PartialEq, Eq)]
 struct Car {
     four_doors: bool,
     passengers: int,
 }
 
+#[derive(PartialEq, Eq)]
 enum Vehicle {
     Car(Car),
     Train(bool),
@@ -41,7 +43,17 @@ fn test_enum_1(passengers: int) {
     let t = Vehicle::Train(true);
     let c1 = Vehicle::Car(Car { passengers, four_doors: true });
     let c2 = Vehicle::Car(Car { passengers, four_doors: false });
-    // assert(t != c1);
-    // assert(c1 != c2);
 }
 
+fn test_neq(passengers: int) {
+    let c1 = Car { passengers, four_doors: true };
+    let c2 = Car { passengers, four_doors: false };
+
+    assert(c1 != c2);
+
+    let t = Vehicle::Train(true);
+    let ca = Vehicle::Car(c1);
+
+    assert(t != ca);
+    assert(t == ca); // FAILS
+}

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -59,7 +59,9 @@ fn check_item<'tcx>(
                     hack_check_def_name(tcx, path.res.def_id(), "core", "cmp::PartialEq"),
                     "non_eq_trait_impl", path);
                 let selfty_path = crate::rust_to_vir_base::ty_resolved_path_to_debug_path(tcx, impll.self_ty);
-                warning_span(impll.self_ty.span, format!("verifier support for the equality impl of {} may be unsound", selfty_path));
+                if hack_check_def_name(tcx, path.res.def_id(), "core", "cmp::PartialEq") {
+                    warning_span(impll.self_ty.span, format!("verifier support for the equality impl of {} may be unsound", selfty_path));
+                }
             } else {
                 unsupported_err!(item.span, "unsupported impl of non-trait", item);
             }

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -59,6 +59,11 @@ fn check_item<'tcx>(
                     hack_check_def_name(tcx, path.res.def_id(), "core", "cmp::PartialEq"),
                     "non_eq_trait_impl", path);
                 let selfty_path = crate::rust_to_vir_base::ty_resolved_path_to_debug_path(tcx, impll.self_ty);
+                // TODO: a type may provide a custom PartialEq implementation, or have interior
+                // mutability; this means that PartialEq::eq may not be the same as structural
+                // (member-wise) adt equality. We should check whether the PartialEq implementation
+                // is compatible with adt equality before allowing these. For now, warn that there
+                // may be unsoundness.
                 if hack_check_def_name(tcx, path.res.def_id(), "core", "cmp::PartialEq") {
                     warning_span(impll.self_ty.span, format!("verifier support for the equality impl of {} may be unsound", selfty_path));
                 }

--- a/verify/rust_verify/src/rust_to_vir_base.rs
+++ b/verify/rust_verify/src/rust_to_vir_base.rs
@@ -195,6 +195,16 @@ pub(crate) fn mid_ty_to_vir_opt<'tcx>(tcx: TyCtxt<'tcx>, ty: rustc_middle::ty::T
     }
 }
 
+pub(crate) fn ty_resolved_path_to_debug_path(_tcx: TyCtxt<'_>, ty: &Ty) -> String {
+    let Ty { hir_id: _, kind, span: _ } = ty;
+    match kind {
+        rustc_hir::TyKind::Path(QPath::Resolved(None, path)) => {
+            path.segments.iter().map(|x| x.ident.name.to_ident_string()).collect::<Vec<_>>().join("::")
+        }
+        _ => panic!("{:?} does not have a resolved path", ty)
+    }
+}
+
 pub(crate) fn ty_to_vir<'tcx>(tcx: TyCtxt<'tcx>, ty: &Ty) -> Typ {
     let Ty { hir_id: _, kind, span } = ty;
     let typ_x = match kind {

--- a/verify/rust_verify/src/util.rs
+++ b/verify/rust_verify/src/util.rs
@@ -24,6 +24,11 @@ pub(crate) fn unsupported_err_span<A>(span: Span, msg: String) -> Result<A, VirE
     )
 }
 
+pub(crate) fn warning_span(span: Span, msg: String) -> () {
+    eprintln!("warning: {}", msg);
+    eprintln!("   --> {:?}", span);
+}
+
 #[macro_export]
 macro_rules! unsupported_err {
     ($span: expr, $msg: expr) => {{


### PR DESCRIPTION
Rust:
```
#[derive(PartialEq, Eq)]
struct Car {
    four_doors: bool,
    passengers: int,
}

#[derive(PartialEq, Eq)]
enum Vehicle {
    Car(Car),
    Train(bool),
}
```

...

```
fn test_neq(passengers: int) {
    let c1 = Car { passengers, four_doors: true };
    let c2 = Car { passengers, four_doors: false };

    assert(c1 != c2);

    let t = Vehicle::Train(true);
    let ca = Vehicle::Car(c1);

    assert(t != ca);
    assert(t == ca); // FAILS
}
```

Air:
```
;; Function-Def test_neq
(check-valid
 (declare-const passengers@ Int)
 (axiom fuel_defaults)
 (declare-const c1@ Car)
 (declare-const c2@ Car)
 (declare-const t@ Vehicle)
 (declare-const ca@ Vehicle)
 (block
  (assume
   (= c1@ (Car/Car true passengers@))
  )
  (assume
   (= c2@ (Car/Car false passengers@))
  )
  (block
   (assert
    "rust_verify/example/adts.rs:52:5: 52:21 (#0)"
    (req%assert (not (= c1@ c2@)))
   )
   (assume
    (ens%assert (not (= c1@ c2@)))
  ))
  (assume
   (= t@ (Vehicle/Train true))
  )
  (assume
   (= ca@ (Vehicle/Car c1@))
  )
  (block
   (assert
    "rust_verify/example/adts.rs:57:5: 57:20 (#0)"
    (req%assert (not (= t@ ca@)))
   )
   (assume
    (ens%assert (not (= t@ ca@)))
  ))
  (block
   (assert
    "rust_verify/example/adts.rs:58:5: 58:20 (#0)"
    (req%assert (= t@ ca@))
   )
   (assume
    (ens%assert (= t@ ca@))
))))
```

Verifies (and fails) correctly.