### PR TITLE
Use the `builtin::Structural` trait to mark types that support structural equality

### DIFF
--- a/verify/Cargo.toml
+++ b/verify/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
   "air",
   "builtin",
+  "builtin_macros",
   "vir",
   "rust_verify",
   "rust_verify_test_macros",

--- a/verify/builtin/Cargo.toml
+++ b/verify/builtin/Cargo.toml
@@ -3,5 +3,4 @@ name = "builtin"
 version = "0.1.0"
 authors = ["Chris Hawblitzel <Chris.Hawblitzel@microsoft.com>"]
 edition = "2018"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/verify/builtin/src/lib.rs
+++ b/verify/builtin/src/lib.rs
@@ -146,7 +146,15 @@ impl std::cmp::Ord for nat {
 
 // TODO(andreal) bake this into the compiler as a lang_item
 #[rustc_diagnostic_item = "builtin::Structural"]
-pub trait Structural {}
+pub trait Structural {
+    #[doc(hidden)]
+    fn assert_receiver_is_structural(&self) -> () {}
+}
+
+#[doc(hidden)]
+pub struct AssertParamIsStructural<T: Structural + ?Sized> {
+    _field: std::marker::PhantomData<T>,
+}
 
 macro_rules! impl_structural {
     ($($t:ty)*) => {

--- a/verify/builtin/src/lib.rs
+++ b/verify/builtin/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(rustc_attrs)]
+
 pub fn admit() {
     unimplemented!();
 }
@@ -140,4 +142,24 @@ impl std::cmp::Ord for nat {
     fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
         unimplemented!()
     }
+}
+
+// TODO(andreal) bake this into the compiler as a lang_item
+#[rustc_diagnostic_item = "builtin::Structural"]
+pub trait Structural {}
+
+macro_rules! impl_structural {
+    ($($t:ty)*) => {
+        $(
+            impl Structural for $t { }
+        )*
+    }
+}
+
+impl_structural! {
+    int nat
+    usize u8 u16 u32 u64 u128
+    isize i8 i16 i32 i64 i128
+    // TODO: support f32 f64 ?
+    bool char
 }

--- a/verify/builtin_macros/Cargo.toml
+++ b/verify/builtin_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "builtin_macros"
+version = "0.1.0"
+authors = ["Chris Hawblitzel <Chris.Hawblitzel@microsoft.com>", "Andrea Lattuada <andrealattuada@inf.ethz.ch>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+synstructure = "0.12"

--- a/verify/builtin_macros/Cargo.toml
+++ b/verify/builtin_macros/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 synstructure = "0.12"
+syn = "1.0"

--- a/verify/builtin_macros/src/lib.rs
+++ b/verify/builtin_macros/src/lib.rs
@@ -4,7 +4,25 @@ use synstructure::decl_derive;
 decl_derive!([Structural] => derive_structural);
 
 fn derive_structural(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    let assert_receiver_is_structural_body = s
+        .variants()
+        .iter()
+        .flat_map(|v| v.ast().fields)
+        .map(|f| {
+            let ty = &f.ty;
+            quote! {
+                let _: ::builtin::AssertParamIsStructural<#ty>;
+            }
+        })
+        .collect::<proc_macro2::TokenStream>();
     s.gen_impl(quote! {
-        gen impl ::builtin::Structural for @Self { }
+        #[automatically_derived]
+        gen impl ::builtin::Structural for @Self {
+            #[inline]
+            #[doc(hidden)]
+            fn assert_receiver_is_structural(&self) -> () {
+                #assert_receiver_is_structural_body
+            }
+        }
     })
 }

--- a/verify/builtin_macros/src/lib.rs
+++ b/verify/builtin_macros/src/lib.rs
@@ -1,0 +1,10 @@
+use quote::quote;
+use synstructure::decl_derive;
+
+decl_derive!([Structural] => derive_structural);
+
+fn derive_structural(s: synstructure::Structure) -> proc_macro2::TokenStream {
+    s.gen_impl(quote! {
+        gen impl ::builtin::Structural for @Self { }
+    })
+}

--- a/verify/rust_verify/example/structural.rs
+++ b/verify/rust_verify/example/structural.rs
@@ -1,0 +1,26 @@
+extern crate builtin;
+#[macro_use] extern crate builtin_macros;
+use builtin::*;
+mod pervasive;
+use pervasive::*;
+
+#[derive(Eq)]
+struct Thing { }
+
+impl std::cmp::PartialEq for Thing {
+    fn eq(&self, _: &Self) -> bool { todo!() }
+}
+
+#[derive(PartialEq, Eq, Structural)]
+struct Car<T> {
+    passengers: T,
+    four_doors: bool,
+}
+
+fn one() {
+    let c1 = Car { passengers: Thing { }, four_doors: true };
+    let c2 = Car { passengers: Thing { }, four_doors: true };
+    assert(c1 == c2);
+}
+
+fn main() { }

--- a/verify/rust_verify/src/main.rs
+++ b/verify/rust_verify/src/main.rs
@@ -25,11 +25,13 @@ pub fn main() {
     // Run verifier callback to build VIR tree and run verifier
     let mut verifier = Verifier::new(our_args);
     let status = rustc_driver::RunCompiler::new(&rustc_args, &mut verifier).run();
-    println!(
-        "Verification results:: verified: {} errors: {}",
-        verifier.count_verified,
-        verifier.errors.len()
-    );
+    if !verifier.encountered_vir_error {
+        println!(
+            "Verification results:: verified: {} errors: {}",
+            verifier.count_verified,
+            verifier.errors.len()
+        );
+    }
     match status {
         Ok(_) => {}
         Err(_) => {

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -196,7 +196,8 @@ fn check_module<'tcx>(
                 unsupported_unless!(
                     def_name == "assert_receiver_is_total_eq"
                         || def_name == "eq"
-                        || def_name == "ne",
+                        || def_name == "ne"
+                        || def_name == "assert_receiver_is_structural",
                     "impl definition in module",
                     id
                 );
@@ -285,7 +286,8 @@ pub fn crate_to_vir<'tcx>(tcx: TyCtxt<'tcx>, krate: &'tcx Crate<'tcx>) -> Result
         unsupported_unless!(
             impl_item_ident == "assert_receiver_is_total_eq"
                 || impl_item_ident == "eq"
-                || impl_item_ident == "ne",
+                || impl_item_ident == "ne"
+                || impl_item_ident == "assert_receiver_is_structural",
             "impl definition",
             impl_item
         );

--- a/verify/rust_verify/src/rust_to_vir_base.rs
+++ b/verify/rust_verify/src/rust_to_vir_base.rs
@@ -1,5 +1,5 @@
-use crate::util::{err_span_str, err_span_string, unsupported_err_span, warning_span};
-use crate::{unsupported, unsupported_err, unsupported_err_unless, unsupported_unless};
+use crate::util::{err_span_str, err_span_string, unsupported_err_span};
+use crate::{unsupported, unsupported_err, unsupported_err_unless};
 use rustc_ast::token::{Token, TokenKind};
 use rustc_ast::tokenstream::TokenTree;
 use rustc_ast::{AttrKind, Attribute, IntTy, MacArgs, UintTy};
@@ -12,7 +12,7 @@ use rustc_span::symbol::Ident;
 use rustc_span::Span;
 use std::rc::Rc;
 use vir::ast::{Idents, IntRange, Mode, Path, Typ, TypX, VirErr};
-use vir::ast_util::{path_to_string, types_equal};
+use vir::ast_util::types_equal;
 
 pub(crate) fn def_to_path<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> Path {
     Rc::new(tcx.def_path(def_id).data.iter().map(|d| Rc::new(format!("{}", d))).collect::<Vec<_>>())
@@ -268,7 +268,7 @@ pub(crate) fn typ_of_node<'tcx>(ctxt: &Ctxt<'tcx>, id: &HirId) -> Typ {
 // Do equality operations on these operands translate into the SMT solver's == operation?
 pub(crate) fn is_smt_equality<'tcx>(
     ctxt: &Ctxt<'tcx>,
-    span: Span,
+    _span: Span,
     id1: &HirId,
     id2: &HirId,
 ) -> bool {
@@ -276,7 +276,7 @@ pub(crate) fn is_smt_equality<'tcx>(
     match (&*t1, &*t2) {
         (TypX::Bool, TypX::Bool) => true,
         (TypX::Int(_), TypX::Int(_)) => true,
-        (TypX::Path(p), TypX::Path(_)) if types_equal(&t1, &t2) => {
+        (TypX::Path(_), TypX::Path(_)) if types_equal(&t1, &t2) => {
             let structural_def_id = ctxt
                 .tcx
                 .get_diagnostic_item(rustc_span::Symbol::intern("builtin::Structural"))

--- a/verify/rust_verify/src/rust_to_vir_expr.rs
+++ b/verify/rust_verify/src/rust_to_vir_expr.rs
@@ -480,8 +480,9 @@ pub(crate) fn expr_to_vir_inner<'tcx>(
             let vlhs = expr_to_vir(ctxt, lhs)?;
             let vrhs = expr_to_vir(ctxt, rhs)?;
             match op.node {
-                BinOpKind::Eq | BinOpKind::Ne => unsupported_unless!(
+                BinOpKind::Eq | BinOpKind::Ne => unsupported_err_unless!(
                     is_smt_equality(ctxt, expr.span, &lhs.hir_id, &rhs.hir_id),
+                    expr.span,
                     "==/!= for non smt equality types",
                     expr
                 ),

--- a/verify/rust_verify/src/util.rs
+++ b/verify/rust_verify/src/util.rs
@@ -59,6 +59,22 @@ macro_rules! unsupported_err_unless {
 }
 
 #[macro_export]
+macro_rules! err_unless {
+    ($assertion: expr, $span: expr, $msg: expr) => {
+        if (!$assertion) {
+            dbg!();
+            crate::util::err_span_string($span, $msg)?;
+        }
+    };
+    ($assertion: expr, $span: expr, $msg: expr, $info: expr) => {
+        if (!$assertion) {
+            dbg!($info);
+            crate::util::err_span_string($span, $msg)?;
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! unsupported {
     ($msg: expr) => {{ panic!("The verifier does not yet support the following Rust feature: {}", $msg) }};
     ($msg: expr, $info: expr) => {{

--- a/verify/rust_verify/tests/adts.rs
+++ b/verify/rust_verify/tests/adts.rs
@@ -66,25 +66,6 @@ test_verify_with_pervasive! {
 }
 
 test_verify_with_pervasive! {
-    #[test] test_neq STRUCTS.to_string() + code_str! {
-        fn test_neq(passengers: int) {
-            let c1 = Car { passengers, four_doors: true };
-            let c2 = Car { passengers, four_doors: false };
-            let c3 = Car { passengers, four_doors: true };
-
-            assert(c1 == c3);
-            assert(c1 != c2);
-
-            let t = Vehicle::Train(true);
-            let ca = Vehicle::Car(c1);
-
-            assert(t != ca);
-            assert(t == ca); // FAILS
-        }
-    } => Err(err) => assert_one_fails(err)
-}
-
-test_verify_with_pervasive! {
     #[test] test_enum_struct code! {
         #[derive(PartialEq, Eq)]
         enum Thing {

--- a/verify/rust_verify/tests/common/mod.rs
+++ b/verify/rust_verify/tests/common/mod.rs
@@ -3,7 +3,7 @@ extern crate rustc_errors;
 extern crate rustc_span;
 
 mod pervasive;
-pub use pervasive::{PERVASIVE, PERVASIVE_IMPORT_PRELUDE};
+pub use pervasive::{LIB, PERVASIVE, PERVASIVE_IMPORT_PRELUDE};
 pub use rust_verify::verifier::ErrorSpan;
 pub use rust_verify_test_macros::{code, code_str};
 
@@ -89,6 +89,7 @@ pub fn verify_with_pervasive(
     code: String,
 ) -> Result<(), Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>> {
     let files = vec![
+        ("lib.rs".to_string(), LIB.to_string()),
         ("pervasive.rs".to_string(), PERVASIVE.to_string()),
         ("test.rs".to_string(), format!("{}\n\n{}", PERVASIVE_IMPORT_PRELUDE, code.as_str())),
     ];
@@ -101,6 +102,7 @@ macro_rules! test_verify_with_pervasive {
         $(#[$attrs])*
         fn $name() {
             let result = verify_with_pervasive($body);
+            #[allow(irrefutable_let_patterns)]
             if let $result = result {
                 $assertions
             } else {
@@ -112,6 +114,7 @@ macro_rules! test_verify_with_pervasive {
         $(#[$attrs])*
         fn $name() {
             let result = verify_with_pervasive($body);
+            #[allow(irrefutable_let_patterns)]
             if let $result = result {
             } else {
                 assert!(false, "{:?} does not match $result", result);
@@ -120,6 +123,7 @@ macro_rules! test_verify_with_pervasive {
     };
 }
 
+#[allow(dead_code)]
 pub fn assert_one_fails(err: Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>) {
     assert_eq!(err.len(), 1);
     assert!(err[0].0.as_ref().expect("span").test_span_line.contains("FAILS"));

--- a/verify/rust_verify/tests/common/pervasive.rs
+++ b/verify/rust_verify/tests/common/pervasive.rs
@@ -1,5 +1,9 @@
-pub const PERVASIVE: &str = crate::common::code_str! {
+pub const LIB: &str = crate::common::code_str! {
     extern crate builtin;
+    extern crate builtin_macros;
+};
+
+pub const PERVASIVE: &str = crate::common::code_str! {
     use builtin::*;
 
     #[proof]
@@ -23,7 +27,12 @@ pub const PERVASIVE: &str = crate::common::code_str! {
 
 pub const PERVASIVE_IMPORT_PRELUDE: &str = crate::common::code_str! {
     extern crate builtin;
+    extern crate builtin_macros;
+    #[allow(unused_imports)]
     use builtin::*;
+    #[allow(unused_imports)]
+    use builtin_macros::*;
     mod pervasive;
+    #[allow(unused_imports)]
     use pervasive::*;
 };

--- a/verify/rust_verify/tests/structural.rs
+++ b/verify/rust_verify/tests/structural.rs
@@ -72,3 +72,15 @@ test_verify_with_pervasive! {
         }
     } => Err(err) => assert_eq!(err.len(), 0)
 }
+
+test_verify_with_pervasive! {
+    #[test] test_not_structural_fields code! {
+        #[derive(PartialEq, Eq)]
+        struct Other { }
+
+        #[derive(PartialEq, Eq, Structural)]
+        struct Thing {
+            o: Other,
+        }
+    } => Err(err) => assert_eq!(err.len(), 0)
+}

--- a/verify/rust_verify/tests/structural.rs
+++ b/verify/rust_verify/tests/structural.rs
@@ -1,0 +1,74 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+const STRUCTS: &str = code_str! {
+    #[derive(PartialEq, Eq, Structural)]
+    struct Car {
+        four_doors: bool,
+        passengers: int,
+    }
+
+    #[derive(PartialEq, Eq, Structural)]
+    enum Vehicle {
+        Car(Car),
+        Train(bool),
+    }
+};
+
+test_verify_with_pervasive! {
+    #[test] test_structural_eq STRUCTS.to_string() + code_str! {
+        fn test_structural_eq(passengers: int) {
+            let c1 = Car { passengers, four_doors: true };
+            let c2 = Car { passengers, four_doors: false };
+            let c3 = Car { passengers, four_doors: true };
+
+            assert(c1 == c3);
+            assert(c1 != c2);
+
+            let t = Vehicle::Train(true);
+            let ca = Vehicle::Car(c1);
+
+            assert(t != ca);
+            assert(t == ca); // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    #[test] test_not_structural_eq code! {
+        #[derive(PartialEq, Eq)]
+        struct Thing {
+            v: bool,
+        }
+
+        fn test_not_structural(passengers: int) {
+            let v1 = Thing { v: true };
+            let v2 = Thing { v: true };
+            assert(v1 == v2);
+        }
+    } => Err(err) => assert_eq!(err.len(), 0)
+}
+
+test_verify_with_pervasive! {
+    #[test] test_not_structural_generic code! {
+        #[derive(PartialEq, Eq, Structural)]
+        struct Thing<V> {
+            v: V,
+        }
+
+        #[derive(Eq, Structural)]
+        struct Other { }
+
+        impl std::cmp::PartialEq for Other {
+            fn eq(&self, _: &Self) -> bool { todo!() }
+        }
+
+        fn test_not_structural(passengers: int) {
+            let v1 = Thing { v: true };
+            let v2 = Thing { v: true };
+            assert(v1 == v2);
+        }
+    } => Err(err) => assert_eq!(err.len(), 0)
+}


### PR DESCRIPTION
This should remove a soundness hole in the smt encoding for `==`

Refer to the tests for code that's now rejected by this change.
The `#[derive(Structural)]` macro derives an implementation of `Structural` with a `: Structural` bound on all type parameters of the Adt to ensure that type arguments are themselves `Structural`.

I'm also using the same type-system "technique" as `core::cmp::Eq` to ensure that all fields of a `Structural` adt have a `Structural` type with an hidden trait function that's filled in with type assertions by the derive macro.