### PR TITLE
Add support for mutual recursion

### DIFF
--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -12,7 +12,6 @@ fn arith_sum_int(i: int) -> int {
     if i <= 0 { 0 } else { i + arith_sum_int(i - 1) }
 }
 
-/*
 #[spec]
 fn arith_sum_nat(i: nat) -> nat {
     decreases(i);
@@ -78,7 +77,6 @@ fn count_down_properties() {
     assert(count_down_b(0) == 0);
     assert(count_down_a(1) == 1);
 }
-
 /*
 // Basic test of mutually recursive statements
 #[spec]
@@ -105,7 +103,6 @@ fn count_down_b_stmt(i:nat) -> nat {
     }
 }
 */
-*/
 // Test decreases of mutually recursive expressions
 #[spec]
 fn count_down_a_tricky(i:nat) -> nat {
@@ -120,10 +117,4 @@ fn count_down_b_tricky(i:nat) -> nat {
 
     if i >= 5 { 0 } else { 1 + count_down_a_tricky(i + 1) }
 }
-
-//#[proof]
-//fn count_down_properties() {
-//    assert(count_down_b(0) == 0);
-//    assert(count_down_a(1) == 1);
-//}
 

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -73,6 +73,7 @@ fn count_down_b(i:nat) -> nat {
     if i == 0 { 0 } else { i + count_down_a(i - 1) }
 }
 
+/*
 // Basic test of mutually recursive statements
 #[spec]
 fn count_down_a_stmt(i:nat) -> nat {
@@ -97,3 +98,4 @@ fn count_down_b_stmt(i:nat) -> nat {
         i + count_down_a_stmt(i - 1) 
     }
 }
+*/

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -77,33 +77,36 @@ fn count_down_properties() {
     assert(count_down_b(0) == 0);
     assert(count_down_a(1) == 1);
 }
-/*
+
+#[proof]
+fn count_down_stmt(i:nat) {
+    decreases(i);
+
+    if i != 0 {
+        count_down_stmt(i - 1);
+    }
+}
+
 // Basic test of mutually recursive statements
-#[spec]
-fn count_down_a_stmt(i:nat) -> nat {
+#[proof]
+fn count_down_a_stmt(i:nat) {
     decreases(i);
 
-    if i == 0 {
-        0 
-    } else { 
-        let r = count_down_b_stmt(i - 1);
-        i + r
+    if i != 0 {
+        count_down_b_stmt(i - 1);
     }
 }
 
-#[spec]
-fn count_down_b_stmt(i:nat) -> nat {
+#[proof]
+fn count_down_b_stmt(i:nat) {
     decreases(i);
 
-    if i == 0 { 
-        0 
-    } else { 
+    if i != 0 { 
         count_down_a_stmt(i - 1);
-        i + count_down_a_stmt(i - 1) 
     }
 }
-*/
-// Test decreases of mutually recursive expressions
+
+// Test invalid decreases of mutually recursive expressions
 #[spec]
 fn count_down_a_tricky(i:nat) -> nat {
     decreases(i);
@@ -118,3 +121,21 @@ fn count_down_b_tricky(i:nat) -> nat {
     if i >= 5 { 0 } else { 1 + count_down_a_tricky(i + 1) }
 }
 
+// Test invalid decreases of mutually recursive statements
+#[proof]
+fn count_down_a_stmt_tricky(i:nat) {
+    decreases(i);
+
+    if i != 0 {
+        count_down_b_stmt_tricky(i + 1);
+    }
+}
+
+#[proof]
+fn count_down_b_stmt_tricky(i:nat) {
+    decreases(i);
+
+    if i != 0 { 
+        count_down_a_stmt_tricky(i + 1);
+    }
+}

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -5,6 +5,7 @@ use pervasive::*;
 
 fn main() {}
 
+
 #[spec]
 fn arith_sum_int(i: int) -> int {
     decreases(i);
@@ -56,3 +57,20 @@ fn arith_sum_test3() {
     reveal_with_fuel(arith_sum_u64, 4);
     assert(arith_sum_u64(3) == 6);
 }
+
+/*
+// Test mutual recursion
+#[spec]
+fn count_down_a(i:nat) -> nat {
+    decreases(i);
+
+    if i == 0 { 0 } else { i + count_down_b(i - 1) }
+}
+
+#[spec]
+fn count_down_b(i:nat) -> nat {
+    decreases(i);
+
+    if i == 0 { 0 } else { i + count_down_a(i - 1) }
+}
+*/

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -58,8 +58,7 @@ fn arith_sum_test3() {
     assert(arith_sum_u64(3) == 6);
 }
 
-/*
-// Test mutual recursion
+// Basic test of mutually recursive expressions
 #[spec]
 fn count_down_a(i:nat) -> nat {
     decreases(i);
@@ -73,4 +72,28 @@ fn count_down_b(i:nat) -> nat {
 
     if i == 0 { 0 } else { i + count_down_a(i - 1) }
 }
-*/
+
+// Basic test of mutually recursive statements
+#[spec]
+fn count_down_a_stmt(i:nat) -> nat {
+    decreases(i);
+
+    if i == 0 {
+        0 
+    } else { 
+        let r = count_down_b_stmt(i - 1);
+        i + r
+    }
+}
+
+#[spec]
+fn count_down_b_stmt(i:nat) -> nat {
+    decreases(i);
+
+    if i == 0 { 
+        0 
+    } else { 
+        count_down_a_stmt(i - 1);
+        i + count_down_a_stmt(i - 1) 
+    }
+}

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -13,13 +13,6 @@ fn arith_sum_int(i: int) -> int {
 }
 
 #[spec]
-fn arith_sum_nat(i: nat) -> nat {
-    decreases(i);
-
-    if i == 0 { 0 } else { i + arith_sum_nat(i - 1) }
-}
-
-#[spec]
 #[opaque]
 fn arith_sum_u64(i: u64) -> u64 {
     decreases(i);
@@ -40,13 +33,17 @@ fn arith_sum_int_nonneg(i: nat) {
 #[proof]
 fn arith_sum_test1() {
     assert(arith_sum_int(0) == 0);
-    assert(arith_sum_int(1) == 1);
+    // Recursive functions default to 1 fuel, so without the assert above,
+    // the following assert will fail
+    assert(arith_sum_int(1) == 1);  
     assert(arith_sum_int(2) == 3);
     assert(arith_sum_int(3) == 6);
 }
 
 #[proof]
 fn arith_sum_test2() {
+    // Instead of writing out intermediate assertions, 
+    // we can instead boost the fuel setting
     reveal_with_fuel(arith_sum_int, 4);
     assert(arith_sum_int(3) == 6);
 }
@@ -57,85 +54,3 @@ fn arith_sum_test3() {
     assert(arith_sum_u64(3) == 6);
 }
 
-// Basic test of mutually recursive expressions
-#[spec]
-fn count_down_a(i:nat) -> nat {
-    decreases(i);
-
-    if i == 0 { 0 } else { 1 + count_down_b(i - 1) }
-}
-
-#[spec]
-fn count_down_b(i:nat) -> nat {
-    decreases(i);
-
-    if i == 0 { 0 } else { 1 + count_down_a(i - 1) }
-}
-
-#[proof]
-fn count_down_properties() {
-    assert(count_down_b(0) == 0);
-    assert(count_down_a(1) == 1);
-}
-
-#[proof]
-fn count_down_stmt(i:nat) {
-    decreases(i);
-
-    if i != 0 {
-        count_down_stmt(i - 1);
-    }
-}
-
-// Basic test of mutually recursive statements
-#[proof]
-fn count_down_a_stmt(i:nat) {
-    decreases(i);
-
-    if i != 0 {
-        count_down_b_stmt(i - 1);
-    }
-}
-
-#[proof]
-fn count_down_b_stmt(i:nat) {
-    decreases(i);
-
-    if i != 0 { 
-        count_down_a_stmt(i - 1);
-    }
-}
-
-// Test invalid decreases of mutually recursive expressions
-#[spec]
-fn count_down_a_tricky(i:nat) -> nat {
-    decreases(i);
-
-    if i == 0 { 0 } else { 1 + count_down_b_tricky(i - 1) }
-}
-
-#[spec]
-fn count_down_b_tricky(i:nat) -> nat {
-    decreases(5 - i);
-
-    if i >= 5 { 0 } else { 1 + count_down_a_tricky(i + 1) }
-}
-
-// Test invalid decreases of mutually recursive statements
-#[proof]
-fn count_down_a_stmt_tricky(i:nat) {
-    decreases(i);
-
-    if i != 0 {
-        count_down_b_stmt_tricky(i + 1);
-    }
-}
-
-#[proof]
-fn count_down_b_stmt_tricky(i:nat) {
-    decreases(i);
-
-    if i != 0 { 
-        count_down_a_stmt_tricky(i + 1);
-    }
-}

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -5,7 +5,6 @@ use pervasive::*;
 
 fn main() {}
 
-
 #[spec]
 fn arith_sum_int(i: int) -> int {
     decreases(i);
@@ -13,6 +12,7 @@ fn arith_sum_int(i: int) -> int {
     if i <= 0 { 0 } else { i + arith_sum_int(i - 1) }
 }
 
+/*
 #[spec]
 fn arith_sum_nat(i: nat) -> nat {
     decreases(i);
@@ -105,7 +105,7 @@ fn count_down_b_stmt(i:nat) -> nat {
     }
 }
 */
-
+*/
 // Test decreases of mutually recursive expressions
 #[spec]
 fn count_down_a_tricky(i:nat) -> nat {

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -75,7 +75,7 @@ fn count_down_b(i:nat) -> nat {
 
 #[proof]
 fn count_down_properties() {
-    //assert(count_down_b(0) == 0);
+    assert(count_down_b(0) == 0);
     assert(count_down_a(1) == 1);
 }
 
@@ -105,3 +105,25 @@ fn count_down_b_stmt(i:nat) -> nat {
     }
 }
 */
+
+// Test decreases of mutually recursive expressions
+#[spec]
+fn count_down_a_tricky(i:nat) -> nat {
+    decreases(i);
+
+    if i == 0 { 0 } else { 1 + count_down_b_tricky(i - 1) }
+}
+
+#[spec]
+fn count_down_b_tricky(i:nat) -> nat {
+    decreases(5 - i);
+
+    if i >= 5 { 0 } else { 1 + count_down_a_tricky(i + 1) }
+}
+
+//#[proof]
+//fn count_down_properties() {
+//    assert(count_down_b(0) == 0);
+//    assert(count_down_a(1) == 1);
+//}
+

--- a/verify/rust_verify/example/recursion.rs
+++ b/verify/rust_verify/example/recursion.rs
@@ -63,14 +63,20 @@ fn arith_sum_test3() {
 fn count_down_a(i:nat) -> nat {
     decreases(i);
 
-    if i == 0 { 0 } else { i + count_down_b(i - 1) }
+    if i == 0 { 0 } else { 1 + count_down_b(i - 1) }
 }
 
 #[spec]
 fn count_down_b(i:nat) -> nat {
     decreases(i);
 
-    if i == 0 { 0 } else { i + count_down_a(i - 1) }
+    if i == 0 { 0 } else { 1 + count_down_a(i - 1) }
+}
+
+#[proof]
+fn count_down_properties() {
+    //assert(count_down_b(0) == 0);
+    assert(count_down_a(1) == 1);
 }
 
 /*

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -13,7 +13,7 @@ pub struct Verifier {
     pub encountered_vir_error: bool,
     pub count_verified: u64,
     // Two error slots that can be filled in if needed.  TODO: Convert to list/vec
-    pub errors: Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>,    
+    pub errors: Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>,
     args: Args,
     pub test_capture_output: Option<std::sync::Arc<std::sync::Mutex<Vec<u8>>>>,
 }

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -207,7 +207,7 @@ impl Verifier {
 
         // Pre-declare the function symbols, to allow for the possibility of non-sorted function usage
         for function in &krate.functions {
-            let commands = vir::func_to_air::func_name_to_air(&function);
+            let commands = vir::func_to_air::func_name_to_air(&ctx, &function)?;
             if commands.len() > 0 {
                 air_context.blank_line();
                 air_context.comment(&("Function-PreDecl ".to_string() + &function.x.name));

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -205,6 +205,18 @@ impl Verifier {
             Self::check_internal_result(air_context.command(&command));
         }
 
+        // Pre-declare the function symbols, to allow for the possibility of non-sorted function usage
+        for function in &krate.functions {
+            let commands = vir::func_to_air::func_name_to_air(&function);
+            if commands.len() > 0 {
+                air_context.blank_line();
+                air_context.comment(&("Function-PreDecl ".to_string() + &function.x.name));
+            }
+            for command in commands.iter() {
+                self.check_result_validity(compiler, &command, air_context.command(&command));
+            }
+        }
+
         for function in &krate.functions {
             let commands = vir::func_to_air::func_decl_to_air(&ctx, &function)?;
             if commands.len() > 0 {

--- a/verify/rust_verify/tests/common/mod.rs
+++ b/verify/rust_verify/tests/common/mod.rs
@@ -128,3 +128,10 @@ pub fn assert_one_fails(err: Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>) {
     assert_eq!(err.len(), 1);
     assert!(err[0].0.as_ref().expect("span").test_span_line.contains("FAILS"));
 }
+
+#[allow(dead_code)]
+pub fn assert_two_fails(err: Vec<(Option<ErrorSpan>, Option<ErrorSpan>)>) {
+    assert_eq!(err.len(), 2);
+    assert!(err[0].0.as_ref().expect("span").test_span_line.contains("FAILS"));
+    assert!(err[1].0.as_ref().expect("span").test_span_line.contains("FAILS"));
+}

--- a/verify/rust_verify/tests/recursion.rs
+++ b/verify/rust_verify/tests/recursion.rs
@@ -101,7 +101,7 @@ test_verify_with_pervasive! {
     
 test_verify_with_pervasive! {
     // Expression that fails to decrease
-    #[test] expr_decrease_fail code! {
+    #[test] expr_decrease_fail_1 code! {
         #[spec]
         fn arith_sum_int(i: int) -> int {
             decreases(i);
@@ -124,6 +124,67 @@ test_verify_with_pervasive! {
         }
     } => Err(err) => assert_one_fails(err)
 }
+
+test_verify_with_pervasive! {
+    // Expression that decreases, but not based on the decreases clause provided
+    #[test] expr_wrong_decreases code! {
+        #[spec]
+        fn arith_sum_int(i: int) -> int {
+            decreases(100 - i);
+
+            if i <= 0 { 0 } else { i + arith_sum_int(i - 1) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Expression that decreases, but not based on the decreases clause provided
+    #[test] expr_wrong_decreases_2 code! {
+        #[spec]
+        fn arith_sum_int(x:nat, i: int) -> int {
+            decreases(x);
+
+            if i <= 0 { 0 } else { i + arith_sum_int(x, i - 1) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Expression that decreases, but not based on the decreases clause provided
+    #[test] expr_wrong_decreases_3 code! {
+        #[spec]
+        fn arith_sum_int(i: int) -> int {
+            decreases(5);
+
+            if i <= 0 { 0 } else { i + arith_sum_int(4) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Expression that doesn't decrease due to extra clause
+    #[test] expr_decrease_fail_2 code! {
+        #[spec]
+        fn arith_sum_int(x:nat, y:nat, i: int) -> int {
+            decreases(i);
+
+            if i <= 0 && x < y { 0 } else { i + arith_sum_int(x, y, i - 1) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Expression that fails to decrease
+    #[test] expr_decrease_fail_3 code! {
+        #[spec]
+        fn arith_sum_int(i: int) -> int {
+            decreases(i);
+
+            if i <= 0 { 0 } else { i + arith_sum_int(i) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
 
 test_verify_with_pervasive! {
     // Mutually recursive expressions fail to decrease

--- a/verify/rust_verify/tests/recursion.rs
+++ b/verify/rust_verify/tests/recursion.rs
@@ -92,13 +92,13 @@ test_verify_with_pervasive! {
         fn count_down_b_stmt(i:nat) {
             decreases(i);
 
-            if i != 0 { 
+            if i != 0 {
                 count_down_a_stmt(i - 1);
             }
         }
     } => Ok(())
 }
-    
+
 test_verify_with_pervasive! {
     // Expression that fails to decrease
     #[test] expr_decrease_fail_1 code! {
@@ -185,7 +185,6 @@ test_verify_with_pervasive! {
     } => Err(err) => assert_one_fails(err)
 }
 
-
 test_verify_with_pervasive! {
     // Mutually recursive expressions fail to decrease
     #[test] mutual_expr_decrease_fail code! {
@@ -221,15 +220,15 @@ test_verify_with_pervasive! {
         fn count_down_b_stmt(i:nat) {
             decreases(i);
 
-            if i != 0 { 
+            if i != 0 {
                 count_down_a_stmt(i + 1);   // FAILS
             }
         }
     } => Err(err) => assert_two_fails(err)
 }
-    
-    // TODO: Expression that fails to decrease in a function returning unit
-    /*
+
+// TODO: Expression that fails to decrease in a function returning unit
+/*
 test_verify_with_pervasive! {
     #[test] unit_expr_decrease_fail code! {
         #[spec]
@@ -243,4 +242,3 @@ test_verify_with_pervasive! {
     } => Err(err) => assert_one_fails(err)
 }
 */
-

--- a/verify/rust_verify/tests/recursion.rs
+++ b/verify/rust_verify/tests/recursion.rs
@@ -1,0 +1,185 @@
+#![feature(rustc_private)]
+#[macro_use]
+mod common;
+use common::*;
+
+test_verify_with_pervasive! {
+    #[test] basic_correctness_expr code! {
+        #[spec]
+        fn arith_sum_nat(i: nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { i + arith_sum_nat(i - 1) }
+        }
+    } => Ok(())
+}
+
+test_verify_with_pervasive! {
+    #[test] basic_correctness_stmt code! {
+        #[proof]
+        fn count_down_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 {
+                count_down_stmt(i - 1);
+            }
+        }
+    } => Ok(())
+}
+
+test_verify_with_pervasive! {
+    // Basic test of mutually recursive expressions
+    #[test] mutually_recursive_expressions code! {
+        #[spec]
+        fn count_down_a(i:nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { 1 + count_down_b(i - 1) }
+        }
+
+        #[spec]
+        fn count_down_b(i:nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { 1 + count_down_a(i - 1) }
+        }
+
+        #[proof]
+        fn count_down_properties() {
+            assert(count_down_b(0) == 0);
+            assert(count_down_a(1) == 1);
+        }
+    } => Ok(())
+}
+
+test_verify_with_pervasive! {
+    // Test that fuel only provides one definition unfolding
+    #[test] mutually_recursive_expressions_insufficient_fuel code! {
+        #[spec]
+        fn count_down_a(i:nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { 1 + count_down_b(i - 1) }
+        }
+
+        #[spec]
+        fn count_down_b(i:nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { 1 + count_down_a(i - 1) }
+        }
+
+        #[proof]
+        fn count_down_properties() {
+            assert(count_down_a(1) == 1);   // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Basic test of mutually recursive statements
+    #[test] mutually_recursive_statements code! {
+        #[proof]
+        fn count_down_a_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 {
+                count_down_b_stmt(i - 1);
+            }
+        }
+
+        #[proof]
+        fn count_down_b_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 { 
+                count_down_a_stmt(i - 1);
+            }
+        }
+    } => Ok(())
+}
+    
+test_verify_with_pervasive! {
+    // Expression that fails to decrease
+    #[test] expr_decrease_fail code! {
+        #[spec]
+        fn arith_sum_int(i: int) -> int {
+            decreases(i);
+
+            if i <= 0 { 0 } else { i + arith_sum_int(i + 1) }  // FAILS
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Statement that fails to decrease
+    #[test] stmt_decrease_fail code! {
+        #[proof]
+        fn count_down_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 {
+                count_down_stmt(i + 1); // FAILS
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Mutually recursive expressions fail to decrease
+    #[test] mutual_expr_decrease_fail code! {
+        #[spec]
+        fn count_down_a(i:nat) -> nat {
+            decreases(i);
+
+            if i == 0 { 0 } else { 1 + count_down_b(i - 1) }  // FAILS
+        }
+
+        #[spec]
+        fn count_down_b(i:nat) -> nat {
+            decreases(5 - i);
+
+            if i >= 5 { 0 } else { 1 + count_down_a(i + 1) }  // FAILS
+        }
+    } => Err(err) => assert_two_fails(err)
+}
+
+test_verify_with_pervasive! {
+    // Mutually recursive statements fail to decrease
+    #[test] mutual_stmt_decrease_fail code! {
+        #[proof]
+        fn count_down_a_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 {
+                count_down_b_stmt(i + 1);   // FAILS
+            }
+        }
+
+        #[proof]
+        fn count_down_b_stmt(i:nat) {
+            decreases(i);
+
+            if i != 0 { 
+                count_down_a_stmt(i + 1);   // FAILS
+            }
+        }
+    } => Err(err) => assert_two_fails(err)
+}
+    
+    // TODO: Expression that fails to decrease in a function returning unit
+    /*
+test_verify_with_pervasive! {
+    #[test] unit_expr_decrease_fail code! {
+        #[spec]
+        fn count_down_tricky(i:nat) {
+            decreases(i);
+
+            if i != 0 {
+                count_down_tricky(i + 1)
+            }
+        }
+    } => Err(err) => assert_one_fails(err)
+}
+*/
+

--- a/verify/vir/src/context.rs
+++ b/verify/vir/src/context.rs
@@ -1,16 +1,16 @@
 use crate::ast::{Function, Ident, Krate, Mode, Path, Variants, VirErr};
 use crate::def::FUEL_ID;
+use crate::scc::Graph;
 use air::ast::{Command, CommandX, Commands, DeclX, MultiOp, Span};
 use air::ast_util::str_typ;
 use std::collections::HashMap;
-use crate::scc::Graph;
 use std::rc::Rc;
 
 pub struct Ctx {
     pub(crate) datatypes: HashMap<Path, Variants>,
     pub(crate) functions: Vec<Function>,
     pub(crate) func_map: HashMap<Ident, Function>,
-    pub(crate) func_call_graph : Graph<Ident>,
+    pub(crate) func_call_graph: Graph<Ident>,
     pub(crate) chosen_triggers: std::cell::RefCell<Vec<(Span, Vec<Vec<String>>)>>, // diagnostics
 }
 

--- a/verify/vir/src/context.rs
+++ b/verify/vir/src/context.rs
@@ -26,10 +26,10 @@ impl Ctx {
         let mut func_call_graph: Graph<Ident> = Graph::new();
         for function in krate.functions.iter() {
             func_map.insert(function.x.name.clone(), function.clone());
-            //crate::recursion::check_no_mutual_recursion(&func_map, function)?;
             crate::recursion::expand_call_graph(&mut func_call_graph, function)?;
             functions.push(function.clone());
         }
+        func_call_graph.compute_sccs();
         let chosen_triggers: std::cell::RefCell<Vec<(Span, Vec<Vec<String>>)>> =
             std::cell::RefCell::new(Vec::new());
         Ok(Ctx { datatypes, functions, func_map, func_call_graph, chosen_triggers })

--- a/verify/vir/src/context.rs
+++ b/verify/vir/src/context.rs
@@ -27,7 +27,7 @@ impl Ctx {
         for function in krate.functions.iter() {
             func_map.insert(function.x.name.clone(), function.clone());
             //crate::recursion::check_no_mutual_recursion(&func_map, function)?;
-            crate::recursion::expand_call_graph(&func_call_graph, function);
+            crate::recursion::expand_call_graph(&mut func_call_graph, function)?;
             functions.push(function.clone());
         }
         let chosen_triggers: std::cell::RefCell<Vec<(Span, Vec<Vec<String>>)>> =

--- a/verify/vir/src/func_to_air.rs
+++ b/verify/vir/src/func_to_air.rs
@@ -114,15 +114,10 @@ fn func_body_to_air(
         let bind_body = func_bind(&function.x.typ_params, &function.x.params, &rec_f_succ, true);
         let forall_zero = Rc::new(ExprX::Bind(bind_zero, eq_zero));
         let forall_body = Rc::new(ExprX::Bind(bind_body, eq_body));
-        let mut rec_typs = vec_map(&*function.x.params, |param| typ_to_air(&param.x.typ));
-        rec_typs.push(str_typ(FUEL_TYPE));
-        let rec_typ = typ_to_air(&function.x.ret.as_ref().unwrap().1);
         let fuel_nat_decl = Rc::new(DeclX::Const(fuel_nat_f, str_typ(FUEL_TYPE)));
-        let rec_decl = Rc::new(DeclX::Fun(rec_f, Rc::new(rec_typs), rec_typ));
         let axiom_zero = Rc::new(DeclX::Axiom(forall_zero));
         let axiom_body = Rc::new(DeclX::Axiom(forall_body));
         commands.push(Rc::new(CommandX::Global(fuel_nat_decl)));
-        commands.push(Rc::new(CommandX::Global(rec_decl)));
         commands.push(Rc::new(CommandX::Global(axiom_zero)));
         commands.push(Rc::new(CommandX::Global(axiom_body)));
         rec_f_def
@@ -182,21 +177,36 @@ pub fn req_ens_to_air(
     Ok(())
 }
 
-/// Returns vector of 0 or 1 commands (to match the calling convention of other AIR-producing
-/// functions) that declare the function symbol itself, if the function is a spec function.
-pub fn func_name_to_air(function: &Function) -> Commands {
+/// Returns vector of commands that declare the function symbol itself, 
+/// as well as any related functions symbols (e.g., recursive versions),
+/// if the function is a spec function.
+pub fn func_name_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirErr> {
     let mut all_typs = vec_map(&function.x.params, |param| typ_to_air(&param.x.typ));
     for _ in function.x.typ_params.iter() {
         all_typs.insert(0, str_typ(crate::def::TYPE));
     }
     let mut commands: Vec<Command> = Vec::new();
     if let (Mode::Spec, Some((_, ret, _))) = (function.x.mode, function.x.ret.as_ref()) {
+        // Declare the function symbol itself
         let typ = typ_to_air(&ret);
         let name = suffix_global_id(&function.x.name);
         let decl = Rc::new(DeclX::Fun(name, Rc::new(all_typs), typ));
         commands.push(Rc::new(CommandX::Global(decl)));
+
+        // Check whether we need to declare the recursive version too
+        if let Some(body) = &function.x.body {
+            let body_exp = crate::ast_to_sst::expr_to_exp(&ctx, &body)?;
+            if crate::recursion::is_recursive_exp(ctx, &function.x.name, &body_exp) {
+                let rec_f = suffix_global_id(&prefix_recursive(&function.x.name));
+                let mut rec_typs = vec_map(&*function.x.params, |param| typ_to_air(&param.x.typ));
+                rec_typs.push(str_typ(FUEL_TYPE));
+                let rec_typ = typ_to_air(&function.x.ret.as_ref().unwrap().1);
+                let rec_decl = Rc::new(DeclX::Fun(rec_f, Rc::new(rec_typs), rec_typ));
+                commands.push(Rc::new(CommandX::Global(rec_decl)));
+            }
+        }
     }
-    Rc::new(commands)
+    Ok(Rc::new(commands))
 }
 
 pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirErr> {

--- a/verify/vir/src/func_to_air.rs
+++ b/verify/vir/src/func_to_air.rs
@@ -99,7 +99,7 @@ fn func_body_to_air(
         let mut args_zero = args.clone();
         let mut args_fuel = args.clone();
         let mut args_succ = args.clone();
-        let mut args_def = args.clone();
+        let mut args_def = args;
         args_zero.push(str_var(ZERO));
         args_fuel.push(str_var(FUEL_LOCAL));
         args_succ.push(str_apply(SUCC, &vec![str_var(FUEL_LOCAL)]));
@@ -177,7 +177,7 @@ pub fn req_ens_to_air(
     Ok(())
 }
 
-/// Returns vector of commands that declare the function symbol itself, 
+/// Returns vector of commands that declare the function symbol itself,
 /// as well as any related functions symbols (e.g., recursive versions),
 /// if the function is a spec function.
 pub fn func_name_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirErr> {
@@ -264,7 +264,7 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirE
                 ens_typs.push(typ_to_air(&typ));
                 ens_params.push(Spanned::new(function.span.clone(), param));
                 if let Some(expr) = typ_invariant(&typ, &ident_var(&suffix_local_id(&name)), true) {
-                    ens_typing_invs.push(expr.clone());
+                    ens_typing_invs.push(expr);
                 }
             }
             req_ens_to_air(

--- a/verify/vir/src/lib.rs
+++ b/verify/vir/src/lib.rs
@@ -12,6 +12,7 @@ pub mod headers;
 pub mod modes;
 mod prelude;
 mod recursion;
+mod scc;
 mod sst;
 mod sst_to_air;
 mod sst_vars;

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -63,13 +63,15 @@ fn check_decrease_rename(ctxt: &Ctxt, span: &Span, args: &Exps) -> Exp {
 }
 
 fn update_decreases_exp<'a>(ctxt: &'a Ctxt, name: &Ident) -> Result<Ctxt<'a>, VirErr> {
-    let function = ctxt.ctx.func_map.get(name).unwrap();
-    let (new_decreases_expr, _) = function.x.decrease.as_ref().unwrap().clone();
+    let function = ctxt.ctx.func_map.get(name).expect("func_map should hold all functions");
+    let (new_decreases_expr, _) = function
+        .x
+        .decrease
+        .as_ref()
+        .expect("shouldn't call update_decreases_exp on a function without a decreases clause")
+        .clone();
     let new_decreases_exp = crate::ast_to_sst::expr_to_exp(ctxt.ctx, &new_decreases_expr)?;
-    Ok(Ctxt {
-        decreases_exp: new_decreases_exp,
-        ..ctxt.clone()
-    })
+    Ok(Ctxt { decreases_exp: new_decreases_exp, ..ctxt.clone() })
 }
 
 // Check that exp terminates

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -1,5 +1,5 @@
 use crate::ast::{BinaryOp, Function, Ident, Params, Typ, TypX, UnaryOp, VirErr};
-use crate::ast_util::{err_str, err_string};
+use crate::ast_util::{err_str};
 use crate::ast_visitor::map_expr_visitor;
 use crate::context::Ctx;
 use crate::def::{
@@ -344,39 +344,3 @@ pub(crate) fn expand_call_graph(
     Ok(())
 }
 
-/*
-pub(crate) fn check_defined_earlier(
-    func_map: &HashMap<Ident, Function>,
-    expr: &crate::ast::Expr,
-) -> Result<crate::ast::Expr, VirErr> {
-    use crate::ast::ExprX;
-
-    match &expr.x {
-        ExprX::Call(x, _, _) | ExprX::Fuel(x, _) => {
-            if !func_map.contains_key(x) {
-                return err_string(
-                    &expr.span,
-                    format!(
-                        "because support for mutual recursion isn't yet implemented, {} must be defined before it is called",
-                        &x
-                    ),
-                );
-            }
-        }
-        _ => {}
-    }
-    Ok(expr.clone())
-}
-
-pub(crate) fn check_no_mutual_recursion(
-    func_map: &HashMap<Ident, Function>,
-    function: &Function,
-) -> Result<(), VirErr> {
-    // Mutual recursion is not implemented yet, so make sure there is no mutual recursion.
-    // Check this by simply forcing all the declarations to be in order.
-    if let Some(body) = &function.x.body {
-        map_expr_visitor(body, &mut |expr| check_defined_earlier(func_map, expr))?;
-    }
-    Ok(())
-}
-*/

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -258,12 +258,14 @@ pub(crate) fn check_termination_exp(
     );
 
     // New body: substitute rec%f(args, fuel) for f(args)
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {
-        ExpX::Call(x, typs, args) if *x == function.x.name => {
-            let rec_x = prefix_recursive(x);
-            let mut args = (**args).clone();
-            args.push(Spanned::new(exp.span.clone(), ExpX::Var(str_ident(FUEL_PARAM))));
-            Spanned::new(exp.span.clone(), ExpX::Call(rec_x, typs.clone(), Rc::new(args)))
+        ExpX::Call(x, typs, args) if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == scc_rep => {
+                let rec_x = prefix_recursive(x);
+                let mut args = (**args).clone();
+                args.push(Spanned::new(exp.span.clone(), ExpX::Var(str_ident(FUEL_PARAM))));
+                Spanned::new(exp.span.clone(), ExpX::Call(rec_x, typs.clone(), Rc::new(args)))
+            
         }
         _ => exp.clone(),
     });

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -304,7 +304,7 @@ pub(crate) fn check_termination_stm(
 }
 
 fn add_call_graph_edges(
-    call_graph: &Graph<Ident>,
+    call_graph: &mut Graph<Ident>,
     src: &Ident,
     expr: &crate::ast::Expr,
 ) -> Result<crate::ast::Expr, VirErr> {
@@ -312,7 +312,7 @@ fn add_call_graph_edges(
 
     match &expr.x {
         ExprX::Call(x, _, _) | ExprX::Fuel(x, _) => {
-            call_graph.add_edge(src, x)
+            call_graph.add_edge(src.clone(), x.clone())
         }
         _ => {}
     }
@@ -320,12 +320,13 @@ fn add_call_graph_edges(
 }
 
 pub(crate) fn expand_call_graph(
-    call_graph: &Graph<Ident>,
+    call_graph: &mut Graph<Ident>,
     function: &Function,
-) {
+) -> Result<(), VirErr> {
     if let Some(body) = &function.x.body {
-        map_expr_visitor(body, &mut |expr| add_call_graph_edges(call_graph, &function.x.name, expr));
+        map_expr_visitor(body, &mut |expr| add_call_graph_edges(call_graph, &function.x.name, expr))?;
     }
+    Ok(())
 }
 
 pub(crate) fn check_defined_earlier(

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -332,22 +332,22 @@ pub(crate) fn check_termination_stm(
         ctx,
     };
     let stm = map_stm_visitor(body, &mut |s| match &s.x {
-        StmX::Call(x, _, args, _) 
-            if *x == function.x.name  
-                || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep => {
-                let new_ctxt = update_decreases_exp(&ctxt, x)?; 
-                let check = check_decrease_rename(&new_ctxt, &s.span, &args);
-                let span = Span {
-                    description: Some("could not prove termination".to_string()),
-                    ..s.span.clone()
-                };
-                let stm_assert = Spanned::new(span, StmX::Assert(check));
-                let stm_block =
-                    Spanned::new(s.span.clone(), StmX::Block(Rc::new(vec![stm_assert, s.clone()])));
-                Ok(stm_block)
-            }, 
+        StmX::Call(x, _, args, _)
+            if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
+        {
+            let new_ctxt = update_decreases_exp(&ctxt, x)?;
+            let check = check_decrease_rename(&new_ctxt, &s.span, &args);
+            let span = Span {
+                description: Some("could not prove termination".to_string()),
+                ..s.span.clone()
+            };
+            let stm_assert = Spanned::new(span, StmX::Assert(check));
+            let stm_block =
+                Spanned::new(s.span.clone(), StmX::Block(Rc::new(vec![stm_assert, s.clone()])));
+            Ok(stm_block)
+        }
         _ => Ok(s.clone()),
-        })?;
+    })?;
     let (stm_decl, stm_assign) = mk_decreases_at_entry(&ctxt, &stm.span);
     let stm_block = Spanned::new(
         stm.span.clone(),

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -149,6 +149,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
     }
 
     pub fn get_scc_size(&self, t: &T) -> usize {
+        assert!(self.has_run);
         match self.mapping.get(&t) {
             Some(i) => self.sccs[*i].size(),
             None => 1,
@@ -156,6 +157,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
     }
 
     pub fn get_scc_rep(&self, t: &T) -> T {
+        assert!(self.has_run);
         assert!(self.mapping.contains_key(&t));
         let id = self.mapping.get(&t).unwrap();
         self.nodes[self.sccs[*id].rep()].t.clone()

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -1,0 +1,172 @@
+/* 
+ * Create a graph and then compute the strongly-connected components
+ * of that graph.
+ * Derived from code written by Travis Hance.
+ */
+use std::cmp::min;
+use std::collections::HashMap;
+
+pub struct Graph<T> {
+    h: HashMap<T, usize>,
+    nodes: Vec<Node<T>>,
+
+    has_run: bool,
+    stack: Vec<usize>,
+    stack_len: usize,
+    index: usize,
+
+    sccs: Vec<SCC>,
+    mapping: HashMap<T, usize>,
+}
+
+struct SCC /* <T> */ {
+    id: usize,
+    nodes: Vec<usize>,
+}
+
+struct Node<T> {
+    t: T,
+    edges: Vec<usize>,
+    index: usize,
+    lowlink: usize,
+    on_stack: bool,
+}
+
+impl SCC {
+    pub fn new(id: usize) -> SCC {
+        SCC {
+            id,
+            nodes: Vec::new(),
+        }
+    }
+
+    fn size(&self) -> usize {
+        self.nodes.len()
+    }
+
+    fn rep(&self) -> usize {
+        self.nodes[0]
+    }
+}
+
+impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
+    pub fn new() -> Graph<T> {
+        Graph {
+            h: HashMap::new(),
+            nodes: Vec::new(),
+            has_run: false,
+            stack: Vec::new(),
+            stack_len: 0,
+            index: 0,
+            sccs: Vec::new(),
+            mapping: HashMap::new(),
+        }
+    }
+
+    pub fn add_node(&mut self, value: T) {
+        if !self.h.contains_key(&value) {
+            self.h.insert(value, self.nodes.len());
+            self.nodes.push(Node {
+                t: value,
+                edges: Vec::new(),
+                index: usize::MAX,
+                lowlink: usize::MAX,
+                on_stack: false,
+            });
+        }
+    }
+
+    fn get_or_add(&mut self, value: T) -> usize {
+        match self.h.get(&value) {
+            Some(v) => *v,
+            None => {
+                self.add_node(value);
+                match self.h.get(&value) {
+                    Some(v) => *v,
+                    None => unreachable!(),
+                }
+            }
+        }
+    }
+
+    pub fn add_edge(&mut self, src: T, dst: T) {
+        let v = self.get_or_add(src);
+        let w = self.get_or_add(dst);
+        self.nodes[v].edges.push(w);
+    }
+
+    #[allow(dead_code)]
+    pub fn add_directed_edge_if_nodes_exist(&mut self, src: T, dst: T) {
+        let v = self.h.get(&src);
+        if let Some(v) = v {
+            let w = self.h.get(&dst);
+            if let Some(w) = w {
+                self.nodes[*v].edges.push(*w);
+            }
+        }
+    }
+
+    fn strongconnect(&mut self, v: usize) {
+        self.nodes[v].index = self.index;
+        self.nodes[v].lowlink = self.index;
+        self.index += 1;
+        self.stack[self.stack_len] = v;
+        self.stack_len += 1;
+
+        self.nodes[v].on_stack = true;
+
+        for i in 0..self.nodes[v].edges.len() {
+            let w = self.nodes[v].edges[i];
+            if self.nodes[w].index == usize::MAX {
+                self.strongconnect(w);
+                self.nodes[v].lowlink = min(self.nodes[v].lowlink, self.nodes[w].lowlink);
+            } else if self.nodes[w].on_stack {
+                self.nodes[v].lowlink = min(self.nodes[v].lowlink, self.nodes[w].index);
+            }
+        }
+
+        if self.nodes[v].lowlink == self.nodes[v].index {
+            let mut component = SCC::new(self.sccs.len());
+            loop {
+                let w = self.stack[self.stack_len - 1];
+                self.stack_len -= 1;
+                self.nodes[w].on_stack = false;
+                component.nodes.push(w);
+                self.mapping.insert(self.nodes[w].t, component.id);
+                if w == v {
+                    break;
+                }
+            }
+            self.sccs.push(component);
+        }
+    }
+
+    pub fn compute_sccs(&mut self) {
+        assert!(!self.has_run);
+        self.has_run = true;
+
+        self.stack.resize(self.nodes.len(), 0);
+
+        for i in 0..self.nodes.len() {
+            if self.nodes[i].index == usize::MAX {
+                self.strongconnect(i);
+            }
+        }
+    }
+
+    pub fn get_scc_size(&self, t: T) -> usize {
+        assert!(self.mapping.contains_key(&t));
+        match self.mapping.get(&t) {
+            Some(i) => self.sccs[*i].size(),
+            None => unreachable!(),
+        }
+    }
+
+    pub fn get_scc_rep(&self, t: T) -> T {
+        assert!(self.mapping.contains_key(&t));
+        match self.mapping.get(&t) {
+            Some(i) => self.nodes[self.sccs[*i].rep()].t,
+            None => unreachable!(),
+        }
+    }
+}

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -78,10 +78,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
             Some(v) => *v,
             None => {
                 self.add_node(value.clone());
-                match self.h.get(&value) {
-                    Some(v) => *v,
-                    None => unreachable!(),
-                }
+                *self.h.get(&value).unwrap()
             }
         }
     }
@@ -160,9 +157,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
 
     pub fn get_scc_rep(&self, t: &T) -> T {
         assert!(self.mapping.contains_key(&t));
-        match self.mapping.get(&t) {
-            Some(i) => self.nodes[self.sccs[*i].rep()].t.clone(),
-            None => unreachable!(),
-        }
+        let id = self.mapping.get(&t).unwrap();
+        self.nodes[self.sccs[*id].rep()].t.clone()
     }
 }

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -154,7 +154,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
         }
     }
 
-    pub fn get_scc_size(&self, t: T) -> usize {
+    pub fn get_scc_size(&self, t: &T) -> usize {
         assert!(self.mapping.contains_key(&t));
         match self.mapping.get(&t) {
             Some(i) => self.sccs[*i].size(),
@@ -162,7 +162,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
         }
     }
 
-    pub fn get_scc_rep(&self, t: T) -> T {
+    pub fn get_scc_rep(&self, t: &T) -> T {
         assert!(self.mapping.contains_key(&t));
         match self.mapping.get(&t) {
             Some(i) => self.nodes[self.sccs[*i].rep()].t.clone(),

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -49,7 +49,7 @@ impl SCC {
     }
 }
 
-impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
+impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
     pub fn new() -> Graph<T> {
         Graph {
             h: HashMap::new(),
@@ -65,7 +65,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
 
     pub fn add_node(&mut self, value: T) {
         if !self.h.contains_key(&value) {
-            self.h.insert(value, self.nodes.len());
+            self.h.insert(value.clone(), self.nodes.len());
             self.nodes.push(Node {
                 t: value,
                 edges: Vec::new(),
@@ -80,7 +80,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
         match self.h.get(&value) {
             Some(v) => *v,
             None => {
-                self.add_node(value);
+                self.add_node(value.clone());
                 match self.h.get(&value) {
                     Some(v) => *v,
                     None => unreachable!(),
@@ -132,7 +132,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
                 self.stack_len -= 1;
                 self.nodes[w].on_stack = false;
                 component.nodes.push(w);
-                self.mapping.insert(self.nodes[w].t, component.id);
+                self.mapping.insert(self.nodes[w].t.clone(), component.id);
                 if w == v {
                     break;
                 }
@@ -165,7 +165,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Copy> Graph<T> {
     pub fn get_scc_rep(&self, t: T) -> T {
         assert!(self.mapping.contains_key(&t));
         match self.mapping.get(&t) {
-            Some(i) => self.nodes[self.sccs[*i].rep()].t,
+            Some(i) => self.nodes[self.sccs[*i].rep()].t.clone(),
             None => unreachable!(),
         }
     }

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -78,7 +78,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
             Some(v) => *v,
             None => {
                 self.add_node(value.clone());
-                *self.h.get(&value).unwrap()
+                *self.h.get(&value).expect("Just added this node, so get should always succeed")
             }
         }
     }
@@ -159,7 +159,7 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
     pub fn get_scc_rep(&self, t: &T) -> T {
         assert!(self.has_run);
         assert!(self.mapping.contains_key(&t));
-        let id = self.mapping.get(&t).unwrap();
+        let id = self.mapping.get(&t).expect("key was present in the line above");
         self.nodes[self.sccs[*id].rep()].t.clone()
     }
 }

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -1,4 +1,4 @@
-/* 
+/*
  * Create a graph and then compute the strongly-connected components
  * of that graph.
  * Derived from code written by Travis Hance.
@@ -34,10 +34,7 @@ struct Node<T> {
 
 impl SCC {
     pub fn new(id: usize) -> SCC {
-        SCC {
-            id,
-            nodes: Vec::new(),
-        }
+        SCC { id, nodes: Vec::new() }
     }
 
     fn size(&self) -> usize {

--- a/verify/vir/src/scc.rs
+++ b/verify/vir/src/scc.rs
@@ -155,10 +155,9 @@ impl<T: std::cmp::Eq + std::hash::Hash + Clone> Graph<T> {
     }
 
     pub fn get_scc_size(&self, t: &T) -> usize {
-        assert!(self.mapping.contains_key(&t));
         match self.mapping.get(&t) {
             Some(i) => self.sccs[*i].size(),
-            None => unreachable!(),
+            None => 1,
         }
     }
 


### PR DESCRIPTION
This PR adds support for mutually recursive function calls, and incidentally allows function calls to functions defined later in the file (i.e., we no longer require the functions in the file to be topologically sorted).  