### PR TITLE
add support for "unit" adt variants (enum variants with no fields)

### DIFF
--- a/verify/rust_verify/src/rust_to_vir_adts.rs
+++ b/verify/rust_verify/src/rust_to_vir_adts.rs
@@ -1,8 +1,8 @@
 use crate::rust_to_vir_base::{
     check_generics, def_id_to_vir_path, get_mode, hack_get_def_name, ty_to_vir,
 };
+use crate::unsupported_unless;
 use crate::util::spanned_new;
-use crate::{unsupported, unsupported_unless};
 use rustc_hir::{Crate, EnumDef, Generics, ItemId, VariantData};
 use rustc_middle::ty::TyCtxt;
 use rustc_span::Span;
@@ -52,9 +52,7 @@ fn check_variant_data<'tcx>(
                     })
                     .collect::<Vec<_>>(),
             ),
-            VariantData::Unit(_) => {
-                unsupported!("unit_adt", variant_data);
-            }
+            VariantData::Unit(_vairant_id) => Rc::new(vec![]),
         }),
     )
 }

--- a/verify/rust_verify/tests/adts.rs
+++ b/verify/rust_verify/tests/adts.rs
@@ -78,3 +78,18 @@ test_verify_with_pervasive! {
         }
     } => Ok(())
 }
+
+test_verify_with_pervasive! {
+    #[test] test_enum_unit code! {
+        #[derive(PartialEq, Eq, Structural)]
+        enum AB {
+            A,
+            B(nat),
+        }
+
+        #[spec]
+        fn is_a(l: AB) -> bool {
+            l == AB::A
+        }
+    } => Ok(())
+}


### PR DESCRIPTION
Rust:

```
        #[derive(PartialEq, Eq, Structural)]
        enum AB {
            A,
            B(nat),
        }

        #[spec]
        fn is_a(l: AB) -> bool {
            l == AB::A
        }
```

Air:

```
;; Datatypes
(declare-datatypes () ((AB (AB/A) (AB/B (AB/B/0 Int)))))
(declare-const TYPE%AB Type)
(declare-fun Poly%AB (AB) Poly)
(declare-fun %Poly%AB (Poly) AB)
(axiom (forall ((x AB)) (!
   (= x (%Poly%AB (Poly%AB x)))
   :pattern ((Poly%AB x))
)))
(axiom (forall ((x Poly)) (!
   (=>
    (has_type x TYPE%AB)
    (= x (Poly%AB (%Poly%AB x)))
   )
   :pattern ((has_type x TYPE%AB))
)))

;; Function-PreDecl is_a
(declare-fun is_a. (AB) Bool)

...

;; Function-Decl is_a
(axiom (fuel_bool_default fuel%is_a))
(axiom (=>
  (fuel_bool fuel%is_a)
  (forall ((l@ AB)) (!
    (= (is_a. l@) (= l@ (AB/A)))
    :pattern ((is_a. l@))
))))
```