### PR TITLE
Switch from Rc to Arc

### DIFF
--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -1,24 +1,24 @@
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
-pub type RawSpan = Rc<dyn std::any::Any + std::marker::Sync + std::marker::Send>;
+pub type RawSpan = Arc<dyn std::any::Any + std::marker::Sync + std::marker::Send>;
 #[derive(Clone)] // for Debug, see ast_util
 pub struct Span {
     pub description: Option<String>,
     pub raw_span: RawSpan,
     pub as_string: String, // if we can't print (description, raw_span), print as_string instead
 }
-pub type SpanOption = Rc<Option<Span>>;
+pub type SpanOption = Arc<Option<Span>>;
 
 pub type TypeError = String;
 
-pub type Ident = Rc<String>;
+pub type Ident = Arc<String>;
 
 pub(crate) type Snapshot = HashMap<Ident, u32>;
 pub(crate) type Snapshots = HashMap<Ident, Snapshot>;
 
-pub type Typ = Rc<TypX>;
-pub type Typs = Rc<Vec<Typ>>;
+pub type Typ = Arc<TypX>;
+pub type Typs = Arc<Vec<Typ>>;
 #[derive(Debug)]
 pub enum TypX {
     Bool,
@@ -29,7 +29,7 @@ pub enum TypX {
 #[derive(Clone, PartialEq, Eq, Hash)] // for Debug, see ast_util
 pub enum Constant {
     Bool(bool),
-    Nat(Rc<String>),
+    Nat(Arc<String>),
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -59,8 +59,8 @@ pub enum MultiOp {
     Distinct,
 }
 
-pub type Binder<A> = Rc<BinderX<A>>;
-pub type Binders<A> = Rc<Vec<Binder<A>>>;
+pub type Binder<A> = Arc<BinderX<A>>;
+pub type Binders<A> = Arc<Vec<Binder<A>>>;
 #[derive(Clone)] // for Debug, see ast_util
 pub struct BinderX<A: Clone> {
     pub name: Ident,
@@ -74,17 +74,17 @@ pub enum Quant {
 }
 
 pub type Trigger = Exprs;
-pub type Triggers = Rc<Vec<Trigger>>;
+pub type Triggers = Arc<Vec<Trigger>>;
 
-pub type Bind = Rc<BindX>;
+pub type Bind = Arc<BindX>;
 #[derive(Clone, Debug)]
 pub enum BindX {
     Let(Binders<Expr>),
     Quant(Quant, Binders<Typ>, Triggers),
 }
 
-pub type Expr = Rc<ExprX>;
-pub type Exprs = Rc<Vec<Expr>>;
+pub type Expr = Arc<ExprX>;
+pub type Exprs = Arc<Vec<Expr>>;
 #[derive(Debug)]
 pub enum ExprX {
     Const(Constant),
@@ -99,8 +99,8 @@ pub enum ExprX {
     LabeledAssertion(SpanOption, Expr),
 }
 
-pub type Stmt = Rc<StmtX>;
-pub type Stmts = Rc<Vec<Stmt>>;
+pub type Stmt = Arc<StmtX>;
+pub type Stmts = Arc<Vec<Stmt>>;
 #[derive(Debug)]
 pub enum StmtX {
     Assume(Expr),
@@ -119,8 +119,8 @@ pub type Variants = Binders<Fields>;
 pub type Datatype = Binder<Variants>;
 pub type Datatypes = Binders<Variants>;
 
-pub type Decl = Rc<DeclX>;
-pub type Decls = Rc<Vec<Decl>>;
+pub type Decl = Arc<DeclX>;
+pub type Decls = Arc<Vec<Decl>>;
 #[derive(Debug)]
 pub enum DeclX {
     Sort(Ident),
@@ -131,15 +131,15 @@ pub enum DeclX {
     Axiom(Expr),
 }
 
-pub type Query = Rc<QueryX>;
+pub type Query = Arc<QueryX>;
 #[derive(Debug)]
 pub struct QueryX {
     pub local: Decls,    // local declarations
     pub assertion: Stmt, // checked by SMT with global and local declarations
 }
 
-pub type Command = Rc<CommandX>;
-pub type Commands = Rc<Vec<Command>>;
+pub type Command = Arc<CommandX>;
+pub type Commands = Arc<Vec<Command>>;
 #[derive(Debug)]
 pub enum CommandX {
     Push,                    // push space for temporary global declarations

--- a/verify/air/src/ast.rs
+++ b/verify/air/src/ast.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::rc::Rc;
 
-pub type RawSpan = Rc<dyn std::any::Any>;
+pub type RawSpan = Rc<dyn std::any::Any + std::marker::Sync + std::marker::Send>;
 #[derive(Clone)] // for Debug, see ast_util
 pub struct Span {
     pub description: Option<String>,

--- a/verify/air/src/ast_util.rs
+++ b/verify/air/src/ast_util.rs
@@ -3,7 +3,7 @@ use crate::ast::{
     Typ, TypX, UnaryOp,
 };
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 impl Debug for Span {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -29,7 +29,7 @@ impl<A: Clone> BinderX<A> {
         &self,
         f: impl FnOnce(&A) -> Result<B, E>,
     ) -> Result<Binder<B>, E> {
-        Ok(Rc::new(BinderX { name: self.name.clone(), a: f(&self.a)? }))
+        Ok(Arc::new(BinderX { name: self.name.clone(), a: f(&self.a)? }))
     }
 }
 
@@ -43,55 +43,55 @@ impl<A: Clone + Debug> std::fmt::Debug for BinderX<A> {
 }
 
 pub fn str_ident(x: &str) -> Ident {
-    Rc::new(x.to_string())
+    Arc::new(x.to_string())
 }
 
 pub fn ident_var(x: &Ident) -> Expr {
-    Rc::new(ExprX::Var(x.clone()))
+    Arc::new(ExprX::Var(x.clone()))
 }
 
 pub fn string_var(x: &String) -> Expr {
-    Rc::new(ExprX::Var(Rc::new(x.clone())))
+    Arc::new(ExprX::Var(Arc::new(x.clone())))
 }
 
 pub fn str_var(x: &str) -> Expr {
-    Rc::new(ExprX::Var(Rc::new(x.to_string())))
+    Arc::new(ExprX::Var(Arc::new(x.to_string())))
 }
 
 pub fn ident_apply(x: &Ident, args: &Vec<Expr>) -> Expr {
-    Rc::new(ExprX::Apply(x.clone(), Rc::new(args.clone())))
+    Arc::new(ExprX::Apply(x.clone(), Arc::new(args.clone())))
 }
 
 pub fn string_apply(x: &String, args: &Vec<Expr>) -> Expr {
-    Rc::new(ExprX::Apply(Rc::new(x.clone()), Rc::new(args.clone())))
+    Arc::new(ExprX::Apply(Arc::new(x.clone()), Arc::new(args.clone())))
 }
 
 pub fn str_apply(x: &str, args: &Vec<Expr>) -> Expr {
-    Rc::new(ExprX::Apply(Rc::new(x.to_string()), Rc::new(args.clone())))
+    Arc::new(ExprX::Apply(Arc::new(x.to_string()), Arc::new(args.clone())))
 }
 
 pub fn int_typ() -> Typ {
-    Rc::new(TypX::Int)
+    Arc::new(TypX::Int)
 }
 
 pub fn bool_typ() -> Typ {
-    Rc::new(TypX::Bool)
+    Arc::new(TypX::Bool)
 }
 
 pub fn ident_typ(x: &Ident) -> Typ {
-    Rc::new(TypX::Named(x.clone()))
+    Arc::new(TypX::Named(x.clone()))
 }
 
 pub fn string_typ(x: &String) -> Typ {
-    Rc::new(TypX::Named(Rc::new(x.clone())))
+    Arc::new(TypX::Named(Arc::new(x.clone())))
 }
 
 pub fn str_typ(x: &str) -> Typ {
-    Rc::new(TypX::Named(Rc::new(x.to_string())))
+    Arc::new(TypX::Named(Arc::new(x.to_string())))
 }
 
 pub fn ident_binder<A: Clone>(x: &Ident, a: &A) -> Binder<A> {
-    Rc::new(BinderX { name: x.clone(), a: a.clone() })
+    Arc::new(BinderX { name: x.clone(), a: a.clone() })
 }
 
 pub fn mk_quantifier(
@@ -100,8 +100,8 @@ pub fn mk_quantifier(
     triggers: &Vec<Trigger>,
     body: &Expr,
 ) -> Expr {
-    Rc::new(ExprX::Bind(
-        Rc::new(BindX::Quant(quant, Rc::new(binders.clone()), Rc::new(triggers.clone()))),
+    Arc::new(ExprX::Bind(
+        Arc::new(BindX::Quant(quant, Arc::new(binders.clone()), Arc::new(triggers.clone()))),
         body.clone(),
     ))
 }
@@ -115,11 +115,11 @@ pub fn mk_exists(binders: &Vec<Binder<Typ>>, triggers: &Vec<Trigger>, body: &Exp
 }
 
 pub fn mk_true() -> Expr {
-    Rc::new(ExprX::Const(Constant::Bool(true)))
+    Arc::new(ExprX::Const(Constant::Bool(true)))
 }
 
 pub fn mk_false() -> Expr {
-    Rc::new(ExprX::Const(Constant::Bool(false)))
+    Arc::new(ExprX::Const(Constant::Bool(false)))
 }
 
 pub fn mk_and(exprs: &Vec<Expr>) -> Expr {
@@ -136,7 +136,7 @@ pub fn mk_and(exprs: &Vec<Expr>) -> Expr {
     } else if exprs.len() == 1 {
         exprs[0].clone()
     } else {
-        Rc::new(ExprX::Multi(MultiOp::And, Rc::new(exprs)))
+        Arc::new(ExprX::Multi(MultiOp::And, Arc::new(exprs)))
     }
 }
 
@@ -154,7 +154,7 @@ pub fn mk_or(exprs: &Vec<Expr>) -> Expr {
     } else if exprs.len() == 1 {
         exprs[0].clone()
     } else {
-        Rc::new(ExprX::Multi(MultiOp::Or, Rc::new(exprs)))
+        Arc::new(ExprX::Multi(MultiOp::Or, Arc::new(exprs)))
     }
 }
 
@@ -163,7 +163,7 @@ pub fn mk_not(e1: &Expr) -> Expr {
         ExprX::Const(Constant::Bool(false)) => mk_true(),
         ExprX::Const(Constant::Bool(true)) => mk_false(),
         ExprX::Unary(UnaryOp::Not, e) => e.clone(),
-        _ => Rc::new(ExprX::Unary(UnaryOp::Not, e1.clone())),
+        _ => Arc::new(ExprX::Unary(UnaryOp::Not, e1.clone())),
     }
 }
 
@@ -173,7 +173,7 @@ pub fn mk_implies(e1: &Expr, e2: &Expr) -> Expr {
         (ExprX::Const(Constant::Bool(true)), _) => e2.clone(),
         (_, ExprX::Const(Constant::Bool(false))) => mk_not(e1),
         (_, ExprX::Const(Constant::Bool(true))) => mk_true(),
-        _ => Rc::new(ExprX::Binary(BinaryOp::Implies, e1.clone(), e2.clone())),
+        _ => Arc::new(ExprX::Binary(BinaryOp::Implies, e1.clone(), e2.clone())),
     }
 }
 
@@ -185,10 +185,10 @@ pub fn mk_ite(e1: &Expr, e2: &Expr, e3: &Expr) -> Expr {
         (_, _, ExprX::Const(Constant::Bool(false))) => mk_and(&vec![e1.clone(), e2.clone()]),
         (_, ExprX::Const(Constant::Bool(true)), _) => mk_implies(&mk_not(e1), e3),
         (_, ExprX::Const(Constant::Bool(false)), _) => mk_and(&vec![mk_not(e1), e3.clone()]),
-        _ => Rc::new(ExprX::IfElse(e1.clone(), e2.clone(), e3.clone())),
+        _ => Arc::new(ExprX::IfElse(e1.clone(), e2.clone(), e3.clone())),
     }
 }
 
 pub fn mk_eq(e1: &Expr, e2: &Expr) -> Expr {
-    Rc::new(ExprX::Binary(BinaryOp::Eq, e1.clone(), e2.clone()))
+    Arc::new(ExprX::Binary(BinaryOp::Eq, e1.clone(), e2.clone()))
 }

--- a/verify/air/src/context.rs
+++ b/verify/air/src/context.rs
@@ -3,7 +3,7 @@ use crate::model::Model;
 use crate::print_parse::Logger;
 use crate::typecheck::Typing;
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::sync::Arc;
 use z3::ast::Dynamic;
 use z3::{FuncDecl, Sort};
 
@@ -24,10 +24,10 @@ pub enum ValidityResult<'a> {
 pub struct Context<'ctx> {
     pub(crate) context: &'ctx z3::Context,
     pub(crate) solver: &'ctx z3::Solver<'ctx>,
-    pub(crate) typs: HashMap<Ident, Rc<Sort<'ctx>>>,
-    pub(crate) vars: HashMap<Ident, Dynamic<'ctx>>, // no Rc; Dynamic implements Clone
-    pub(crate) funs: HashMap<Ident, Rc<FuncDecl<'ctx>>>,
-    pub(crate) assert_infos: HashMap<Ident, Rc<AssertionInfo>>,
+    pub(crate) typs: HashMap<Ident, Arc<Sort<'ctx>>>,
+    pub(crate) vars: HashMap<Ident, Dynamic<'ctx>>, // no Arc; Dynamic implements Clone
+    pub(crate) funs: HashMap<Ident, Arc<FuncDecl<'ctx>>>,
+    pub(crate) assert_infos: HashMap<Ident, Arc<AssertionInfo>>,
     pub(crate) assert_infos_count: u64,
     pub(crate) typing: Typing,
     pub(crate) debug: bool,

--- a/verify/air/src/model.rs
+++ b/verify/air/src/model.rs
@@ -79,7 +79,7 @@ impl<'a> Model<'a> {
                     let var_smt = new_const(context, &var_name, &typ);
                     let val = self.lookup_z3_var(&var_name, &var_smt);
                     value_snapshot.insert(var_name.clone(), val);
-                    //value_snapshot.insert(Rc::new((*var_name).clone()), val);
+                    //value_snapshot.insert(Arc::new((*var_name).clone()), val);
                 } else {
                     panic!("Expected local vars to all be constants at this point");
                 }

--- a/verify/air/src/print_parse.rs
+++ b/verify/air/src/print_parse.rs
@@ -6,7 +6,7 @@ use crate::ast::{
 use crate::util::vec_map;
 use sise::{Node, Writer};
 use std::io::Write;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub fn str_to_node(s: &str) -> Node {
     Node::Atom(s.to_string())
@@ -188,7 +188,7 @@ pub(crate) fn binders_to_node<A: Clone, F: Fn(&A) -> Node>(binders: &Binders<A>,
 }
 
 pub(crate) fn multibinder_to_node<A: Clone, F: Fn(&A) -> Node>(
-    binder: &Binder<Rc<Vec<A>>>,
+    binder: &Binder<Arc<Vec<A>>>,
     f: &F,
 ) -> Node {
     let mut nodes: Vec<Node> = Vec::new();
@@ -200,7 +200,7 @@ pub(crate) fn multibinder_to_node<A: Clone, F: Fn(&A) -> Node>(
 }
 
 pub(crate) fn multibinders_to_node<A: Clone, F: Fn(&A) -> Node>(
-    binders: &Binders<Rc<Vec<A>>>,
+    binders: &Binders<Arc<Vec<A>>>,
     f: &F,
 ) -> Node {
     Node::List(vec_map(binders, |b| multibinder_to_node(b, f)))
@@ -473,7 +473,7 @@ fn is_symbol(s: &String) -> bool {
     s.len() > 0 && s.chars().all(is_symbol_char)
 }
 
-fn map_nodes_to_vec<A, F>(nodes: &[Node], f: F) -> Result<Rc<Vec<A>>, String>
+fn map_nodes_to_vec<A, F>(nodes: &[Node], f: F) -> Result<Arc<Vec<A>>, String>
 where
     F: Fn(&Node) -> Result<A, String>,
 {
@@ -481,28 +481,30 @@ where
     for node in nodes.iter() {
         v.push(f(node)?);
     }
-    Ok(Rc::new(v))
+    Ok(Arc::new(v))
 }
 
 pub(crate) fn node_to_typ(node: &Node) -> Result<Typ, String> {
     match node {
-        Node::Atom(s) if s.to_string() == "Bool" => Ok(Rc::new(TypX::Bool)),
-        Node::Atom(s) if s.to_string() == "Int" => Ok(Rc::new(TypX::Int)),
-        Node::Atom(s) if is_symbol(s) => Ok(Rc::new(TypX::Named(Rc::new(s.clone())))),
+        Node::Atom(s) if s.to_string() == "Bool" => Ok(Arc::new(TypX::Bool)),
+        Node::Atom(s) if s.to_string() == "Int" => Ok(Arc::new(TypX::Int)),
+        Node::Atom(s) if is_symbol(s) => Ok(Arc::new(TypX::Named(Arc::new(s.clone())))),
         _ => Err(format!("expected type, found: {}", node_to_string(node))),
     }
 }
 
 pub(crate) fn node_to_expr(node: &Node) -> Result<Expr, String> {
     match node {
-        Node::Atom(s) if s.to_string() == "true" => Ok(Rc::new(ExprX::Const(Constant::Bool(true)))),
+        Node::Atom(s) if s.to_string() == "true" => {
+            Ok(Arc::new(ExprX::Const(Constant::Bool(true))))
+        }
         Node::Atom(s) if s.to_string() == "false" => {
-            Ok(Rc::new(ExprX::Const(Constant::Bool(false))))
+            Ok(Arc::new(ExprX::Const(Constant::Bool(false))))
         }
         Node::Atom(s) if s.len() > 0 && s.chars().all(|c| c.is_ascii_digit()) => {
-            Ok(Rc::new(ExprX::Const(Constant::Nat(Rc::new(s.clone())))))
+            Ok(Arc::new(ExprX::Const(Constant::Nat(Arc::new(s.clone())))))
         }
-        Node::Atom(s) if is_symbol(s) => Ok(Rc::new(ExprX::Var(Rc::new(s.clone())))),
+        Node::Atom(s) if is_symbol(s) => Ok(Arc::new(ExprX::Var(Arc::new(s.clone())))),
         Node::List(nodes) if nodes.len() > 0 => {
             match &nodes[..] {
                 [Node::Atom(s), Node::Atom(label), e]
@@ -510,16 +512,16 @@ pub(crate) fn node_to_expr(node: &Node) -> Result<Expr, String> {
                         && label.starts_with("\"")
                         && label.ends_with("\"") =>
                 {
-                    let raw_span = Rc::new(());
+                    let raw_span = Arc::new(());
                     let as_string = label[1..label.len() - 1].to_string();
-                    let span = Rc::new(Some(Span { description: None, raw_span, as_string }));
+                    let span = Arc::new(Some(Span { description: None, raw_span, as_string }));
                     let expr = node_to_expr(e)?;
-                    return Ok(Rc::new(ExprX::LabeledAssertion(span, expr)));
+                    return Ok(Arc::new(ExprX::LabeledAssertion(span, expr)));
                 }
                 [Node::Atom(s), Node::Atom(snap), Node::Atom(x)]
                     if s.to_string() == "old" && is_symbol(snap) && is_symbol(x) =>
                 {
-                    return Ok(Rc::new(ExprX::Old(Rc::new(snap.clone()), Rc::new(x.clone()))));
+                    return Ok(Arc::new(ExprX::Old(Arc::new(snap.clone()), Arc::new(x.clone()))));
                 }
                 [Node::Atom(s), Node::List(binders), e] if s.to_string() == "let" => {
                     return node_to_let_expr(binders, e);
@@ -566,15 +568,15 @@ pub(crate) fn node_to_expr(node: &Node) -> Result<Expr, String> {
                 _ => None,
             };
             match (args.len(), uop, bop, lop, ite, fun) {
-                (1, Some(op), _, _, _, _) => Ok(Rc::new(ExprX::Unary(op, args[0].clone()))),
+                (1, Some(op), _, _, _, _) => Ok(Arc::new(ExprX::Unary(op, args[0].clone()))),
                 (2, _, Some(op), _, _, _) => {
-                    Ok(Rc::new(ExprX::Binary(op, args[0].clone(), args[1].clone())))
+                    Ok(Arc::new(ExprX::Binary(op, args[0].clone(), args[1].clone())))
                 }
-                (_, _, _, Some(op), _, _) => Ok(Rc::new(ExprX::Multi(op, args))),
+                (_, _, _, Some(op), _, _) => Ok(Arc::new(ExprX::Multi(op, args))),
                 (_, _, _, _, true, _) => {
-                    Ok(Rc::new(ExprX::IfElse(args[0].clone(), args[1].clone(), args[2].clone())))
+                    Ok(Arc::new(ExprX::IfElse(args[0].clone(), args[1].clone(), args[2].clone())))
                 }
-                (_, _, _, _, _, Some(x)) => Ok(Rc::new(ExprX::Apply(Rc::new(x.clone()), args))),
+                (_, _, _, _, _, Some(x)) => Ok(Arc::new(ExprX::Apply(Arc::new(x.clone()), args))),
                 _ => Err(format!("expected expression, found: {}", node_to_string(node))),
             }
         }
@@ -595,7 +597,7 @@ where
         Node::List(nodes) => match &nodes[..] {
             [Node::Atom(name), node] if is_symbol(name) => {
                 let a = f(node)?;
-                return Ok(Rc::new(BinderX { name: Rc::new(name.clone()), a }));
+                return Ok(Arc::new(BinderX { name: Arc::new(name.clone()), a }));
             }
             _ => {}
         },
@@ -604,7 +606,7 @@ where
     Err(format!("expected binder (...), found: {}", node_to_string(node)))
 }
 
-fn node_to_multibinder<A, F>(node: &Node, f: &F) -> Result<Binder<Rc<Vec<A>>>, String>
+fn node_to_multibinder<A, F>(node: &Node, f: &F) -> Result<Binder<Arc<Vec<A>>>, String>
 where
     A: Clone,
     F: Fn(&Node) -> Result<A, String>,
@@ -616,7 +618,7 @@ where
                 for node in &nodes[1..] {
                     tail.push(f(node)?);
                 }
-                return Ok(Rc::new(BinderX { name: Rc::new(name.clone()), a: Rc::new(tail) }));
+                return Ok(Arc::new(BinderX { name: Arc::new(name.clone()), a: Arc::new(tail) }));
             }
             _ => {}
         },
@@ -634,25 +636,25 @@ where
     for node in nodes {
         binders.push(node_to_binder(node, f)?);
     }
-    Ok(Rc::new(binders))
+    Ok(Arc::new(binders))
 }
 
-fn nodes_to_multibinders<A, F>(nodes: &[Node], f: &F) -> Result<Binders<Rc<Vec<A>>>, String>
+fn nodes_to_multibinders<A, F>(nodes: &[Node], f: &F) -> Result<Binders<Arc<Vec<A>>>, String>
 where
     A: Clone,
     F: Fn(&Node) -> Result<A, String>,
 {
-    let mut binders: Vec<Binder<Rc<Vec<A>>>> = Vec::new();
+    let mut binders: Vec<Binder<Arc<Vec<A>>>> = Vec::new();
     for node in nodes {
         binders.push(node_to_multibinder(node, f)?);
     }
-    Ok(Rc::new(binders))
+    Ok(Arc::new(binders))
 }
 
 fn node_to_let_expr(binder_nodes: &[Node], expr: &Node) -> Result<Expr, String> {
     let binders = nodes_to_binders(binder_nodes, &node_to_expr)?;
-    let bind = Rc::new(BindX::Let(binders));
-    Ok(Rc::new(ExprX::Bind(bind, node_to_expr(expr)?)))
+    let bind = Arc::new(BindX::Let(binders));
+    Ok(Arc::new(ExprX::Bind(bind, node_to_expr(expr)?)))
 }
 
 fn nodes_to_triggers(nodes: &[Node]) -> Result<Triggers, String> {
@@ -670,7 +672,7 @@ fn nodes_to_triggers(nodes: &[Node]) -> Result<Triggers, String> {
         }
         expect_pattern = !expect_pattern;
     }
-    Ok(Rc::new(triggers))
+    Ok(Arc::new(triggers))
 }
 
 fn node_to_quant_expr(quant: Quant, binder_nodes: &[Node], expr: &Node) -> Result<Expr, String> {
@@ -678,12 +680,12 @@ fn node_to_quant_expr(quant: Quant, binder_nodes: &[Node], expr: &Node) -> Resul
     let (body, triggers) = match &expr {
         Node::List(nodes) if nodes.len() >= 2 => match &nodes[0] {
             Node::Atom(s) if s.to_string() == "!" => (&nodes[1], nodes_to_triggers(&nodes[2..])?),
-            _ => (expr, Rc::new(vec![])),
+            _ => (expr, Arc::new(vec![])),
         },
-        _ => (expr, Rc::new(vec![])),
+        _ => (expr, Arc::new(vec![])),
     };
-    let bind = Rc::new(BindX::Quant(quant, binders, triggers));
-    Ok(Rc::new(ExprX::Bind(bind, node_to_expr(body)?)))
+    let bind = Arc::new(BindX::Quant(quant, binders, triggers));
+    Ok(Arc::new(ExprX::Bind(bind, node_to_expr(body)?)))
 }
 
 pub(crate) fn node_to_stmt(node: &Node) -> Result<Stmt, String> {
@@ -691,39 +693,39 @@ pub(crate) fn node_to_stmt(node: &Node) -> Result<Stmt, String> {
         Node::List(nodes) => match &nodes[..] {
             [Node::Atom(s), e] if s.to_string() == "assume" => {
                 let expr = node_to_expr(&e)?;
-                Ok(Rc::new(StmtX::Assume(expr)))
+                Ok(Arc::new(StmtX::Assume(expr)))
             }
             [Node::Atom(s), e] if s.to_string() == "assert" => {
                 let expr = node_to_expr(&e)?;
-                Ok(Rc::new(StmtX::Assert(Rc::new(None), expr)))
+                Ok(Arc::new(StmtX::Assert(Arc::new(None), expr)))
             }
             [Node::Atom(s), Node::Atom(x)] if s.to_string() == "havoc" && is_symbol(x) => {
-                Ok(Rc::new(StmtX::Havoc(Rc::new(x.clone()))))
+                Ok(Arc::new(StmtX::Havoc(Arc::new(x.clone()))))
             }
             [Node::Atom(s), Node::Atom(x), e] if s.to_string() == "assign" && is_symbol(x) => {
                 let expr = node_to_expr(&e)?;
-                Ok(Rc::new(StmtX::Assign(Rc::new(x.clone()), expr)))
+                Ok(Arc::new(StmtX::Assign(Arc::new(x.clone()), expr)))
             }
             [Node::Atom(s), Node::Atom(snap)] if s.to_string() == "snapshot" && is_symbol(snap) => {
-                Ok(Rc::new(StmtX::Snapshot(Rc::new(snap.clone()))))
+                Ok(Arc::new(StmtX::Snapshot(Arc::new(snap.clone()))))
             }
             [Node::Atom(s), Node::Atom(label), e]
                 if s.to_string() == "assert"
                     && label.starts_with("\"")
                     && label.ends_with("\"") =>
             {
-                let raw_span = Rc::new(());
+                let raw_span = Arc::new(());
                 let as_string = label[1..label.len() - 1].to_string();
                 let span = Span { description: None, raw_span, as_string };
                 let expr = node_to_expr(&e)?;
-                Ok(Rc::new(StmtX::Assert(Rc::new(Some(span)), expr)))
+                Ok(Arc::new(StmtX::Assert(Arc::new(Some(span)), expr)))
             }
             _ => match &nodes[0] {
                 Node::Atom(s) if s.to_string() == "block" => {
-                    Ok(Rc::new(StmtX::Block(nodes_to_stmts(&nodes[1..])?)))
+                    Ok(Arc::new(StmtX::Block(nodes_to_stmts(&nodes[1..])?)))
                 }
                 Node::Atom(s) if s.to_string() == "switch" => {
-                    Ok(Rc::new(StmtX::Switch(nodes_to_stmts(&nodes[1..])?)))
+                    Ok(Arc::new(StmtX::Switch(nodes_to_stmts(&nodes[1..])?)))
                 }
                 _ => Err(format!("expected statement, found: {}", node_to_string(node))),
             },
@@ -740,7 +742,7 @@ fn node_to_decl(node: &Node) -> Result<Decl, String> {
     match node {
         Node::List(nodes) => match &nodes[..] {
             [Node::Atom(s), Node::Atom(x)] if s.to_string() == "declare-sort" && is_symbol(x) => {
-                Ok(Rc::new(DeclX::Sort(Rc::new(x.clone()))))
+                Ok(Arc::new(DeclX::Sort(Arc::new(x.clone()))))
             }
             [Node::Atom(s), Node::List(l), Node::List(datatypes)]
                 if s.to_string() == "declare-datatypes" && l.len() == 0 =>
@@ -748,13 +750,13 @@ fn node_to_decl(node: &Node) -> Result<Decl, String> {
                 let ds = nodes_to_multibinders(datatypes, &|variant| {
                     node_to_multibinder(variant, &|field| node_to_binder(field, &node_to_typ))
                 })?;
-                Ok(Rc::new(DeclX::Datatypes(ds)))
+                Ok(Arc::new(DeclX::Datatypes(ds)))
             }
             [Node::Atom(s), Node::Atom(x), t]
                 if s.to_string() == "declare-const" && is_symbol(x) =>
             {
                 let typ = node_to_typ(t)?;
-                Ok(Rc::new(DeclX::Const(Rc::new(x.clone()), typ)))
+                Ok(Arc::new(DeclX::Const(Arc::new(x.clone()), typ)))
             }
             [Node::Atom(s), Node::Atom(x), Node::List(ts), t]
                 if s.to_string() == "declare-fun" && is_symbol(x) =>
@@ -764,15 +766,15 @@ fn node_to_decl(node: &Node) -> Result<Decl, String> {
                     typs.push(node_to_typ(ta)?);
                 }
                 let typ = node_to_typ(t)?;
-                Ok(Rc::new(DeclX::Fun(Rc::new(x.clone()), Rc::new(typs), typ)))
+                Ok(Arc::new(DeclX::Fun(Arc::new(x.clone()), Arc::new(typs), typ)))
             }
             [Node::Atom(s), Node::Atom(x), t] if s.to_string() == "declare-var" && is_symbol(x) => {
                 let typ = node_to_typ(t)?;
-                Ok(Rc::new(DeclX::Var(Rc::new(x.clone()), typ)))
+                Ok(Arc::new(DeclX::Var(Arc::new(x.clone()), typ)))
             }
             [Node::Atom(s), e] if s.to_string() == "axiom" => {
                 let expr = node_to_expr(e)?;
-                Ok(Rc::new(DeclX::Axiom(expr)))
+                Ok(Arc::new(DeclX::Axiom(expr)))
             }
             _ => Err(format!("expected declaration, found: {}", node_to_string(node))),
         },
@@ -788,17 +790,17 @@ pub(crate) fn node_to_command(node: &Node) -> Result<Command, String> {
     match node {
         Node::List(nodes) if nodes.len() >= 1 => match &nodes[0] {
             Node::Atom(s) if s.to_string() == "push" && nodes.len() == 1 => {
-                Ok(Rc::new(CommandX::Push))
+                Ok(Arc::new(CommandX::Push))
             }
             Node::Atom(s) if s.to_string() == "pop" && nodes.len() == 1 => {
-                Ok(Rc::new(CommandX::Pop))
+                Ok(Arc::new(CommandX::Pop))
             }
             Node::Atom(s) if s.to_string() == "set-option" && nodes.len() == 3 => {
                 match &nodes[..] {
                     [_, Node::Atom(option), Node::Atom(value)] if option.starts_with(":") => {
-                        let opt = Rc::new(option[1..].to_string());
-                        let val = Rc::new(value.clone());
-                        Ok(Rc::new(CommandX::SetOption(opt, val)))
+                        let opt = Arc::new(option[1..].to_string());
+                        let val = Arc::new(value.clone());
+                        Ok(Arc::new(CommandX::SetOption(opt, val)))
                     }
                     _ => Err(format!("expected command, found: {}", node_to_string(node))),
                 }
@@ -806,12 +808,12 @@ pub(crate) fn node_to_command(node: &Node) -> Result<Command, String> {
             Node::Atom(s) if s.to_string() == "check-valid" && nodes.len() >= 2 => {
                 let assertion = node_to_stmt(&nodes[nodes.len() - 1])?;
                 let local = nodes_to_decls(&nodes[1..nodes.len() - 1])?;
-                let query = Rc::new(QueryX { local, assertion });
-                Ok(Rc::new(CommandX::CheckValid(query)))
+                let query = Arc::new(QueryX { local, assertion });
+                Ok(Arc::new(CommandX::CheckValid(query)))
             }
             _ => {
                 let decl = node_to_decl(&node)?;
-                Ok(Rc::new(CommandX::Global(decl)))
+                Ok(Arc::new(CommandX::Global(decl)))
             }
         },
         _ => Err(format!("expected command, found: {}", node_to_string(node))),

--- a/verify/air/src/var_to_const.rs
+++ b/verify/air/src/var_to_const.rs
@@ -4,7 +4,7 @@ use crate::ast::{
 };
 use crate::ast_util::string_var;
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::sync::Arc;
 
 fn find_version(versions: &HashMap<Ident, u32>, x: &String) -> u32 {
     *versions.get(x).unwrap_or_else(|| panic!("variable {} not declared", x))
@@ -18,13 +18,13 @@ fn lower_expr_visitor(versions: &HashMap<Ident, u32>, snapshots: &Snapshots, exp
     match &**expr {
         ExprX::Var(x) if versions.contains_key(x) => {
             let xn = rename_var(x, find_version(&versions, x));
-            Rc::new(ExprX::Var(Rc::new(xn)))
+            Arc::new(ExprX::Var(Arc::new(xn)))
         }
         ExprX::Old(snap, x) if snapshots.contains_key(snap) && snapshots[snap].contains_key(x) => {
             let xn = rename_var(x, find_version(&snapshots[snap], x));
-            Rc::new(ExprX::Var(Rc::new(xn)))
+            Arc::new(ExprX::Var(Arc::new(xn)))
         }
-        ExprX::Old(_, x) => Rc::new(ExprX::Var(x.clone())),
+        ExprX::Old(_, x) => Arc::new(ExprX::Var(x.clone())),
         _ => expr.clone(),
     }
 }
@@ -50,31 +50,31 @@ fn lower_stmt(
             let n = find_version(&versions, x);
             let typ = types[x].clone();
             versions.insert(x.clone(), n + 1);
-            let x = Rc::new(rename_var(x, n + 1));
+            let x = Arc::new(rename_var(x, n + 1));
             if !version_decls.contains(&x) {
-                let decl = Rc::new(DeclX::Const(x.clone(), typ));
+                let decl = Arc::new(DeclX::Const(x.clone(), typ));
                 decls.push(decl);
                 version_decls.insert(x.clone());
             }
             match &*stmt {
                 StmtX::Assign(_, e) => {
-                    let expr1 = Rc::new(ExprX::Var(x));
-                    let expr = Rc::new(ExprX::Binary(BinaryOp::Eq, expr1, e.clone()));
-                    Rc::new(StmtX::Assume(expr))
+                    let expr1 = Arc::new(ExprX::Var(x));
+                    let expr = Arc::new(ExprX::Binary(BinaryOp::Eq, expr1, e.clone()));
+                    Arc::new(StmtX::Assume(expr))
                 }
-                _ => Rc::new(StmtX::Block(Rc::new(vec![]))),
+                _ => Arc::new(StmtX::Block(Arc::new(vec![]))),
             }
         }
         StmtX::Snapshot(snap) => {
             snapshots.insert(snap.clone(), versions.clone());
-            Rc::new(StmtX::Block(Rc::new(vec![])))
+            Arc::new(StmtX::Block(Arc::new(vec![])))
         }
         StmtX::Block(ss) => {
             let mut stmts: Vec<Stmt> = Vec::new();
             for s in ss.iter() {
                 stmts.push(lower_stmt(decls, versions, version_decls, snapshots, types, s));
             }
-            Rc::new(StmtX::Block(Rc::new(stmts)))
+            Arc::new(StmtX::Block(Arc::new(stmts)))
         }
         StmtX::Switch(ss) if ss.len() == 0 => stmt,
         StmtX::Switch(ss) => {
@@ -108,13 +108,13 @@ fn lower_stmt(
                     if versions_i[x] < versions[x] {
                         let xk = string_var(&rename_var(x, versions_i[x]));
                         let xm = string_var(&rename_var(x, versions[x]));
-                        let eq = Rc::new(ExprX::Binary(BinaryOp::Eq, xm, xk));
-                        branch.push(Rc::new(StmtX::Assume(eq)));
+                        let eq = Arc::new(ExprX::Binary(BinaryOp::Eq, xm, xk));
+                        branch.push(Arc::new(StmtX::Assume(eq)));
                     }
                 }
-                stmts[i] = Rc::new(StmtX::Block(Rc::new(branch)));
+                stmts[i] = Arc::new(StmtX::Block(Arc::new(branch)));
             }
-            Rc::new(StmtX::Switch(Rc::new(stmts)))
+            Arc::new(StmtX::Switch(Arc::new(stmts)))
         }
     }
 }
@@ -131,15 +131,15 @@ pub(crate) fn lower_query(query: &Query) -> (Query, Snapshots, Vec<Decl>) {
     for decl in local.iter() {
         if let DeclX::Axiom(expr) = &**decl {
             let decl_x = DeclX::Axiom(lower_expr(&versions, &snapshots, expr));
-            decls.push(Rc::new(decl_x));
+            decls.push(Arc::new(decl_x));
         } else {
             decls.push(decl.clone());
         }
         if let DeclX::Var(x, t) = &**decl {
             versions.insert(x.clone(), 0);
             types.insert(x.clone(), t.clone());
-            let x = Rc::new(rename_var(x, 0));
-            let decl = Rc::new(DeclX::Const(x.clone(), t.clone()));
+            let x = Arc::new(rename_var(x, 0));
+            let decl = Arc::new(DeclX::Const(x.clone(), t.clone()));
             decls.push(decl);
         }
         if let DeclX::Const(_, _) = &**decl {
@@ -154,6 +154,6 @@ pub(crate) fn lower_query(query: &Query) -> (Query, Snapshots, Vec<Decl>) {
         &types,
         assertion,
     );
-    let local = Rc::new(decls);
-    (Rc::new(QueryX { local, assertion }), snapshots, local_vars)
+    let local = Arc::new(decls);
+    (Arc::new(QueryX { local, assertion }), snapshots, local_vars)
 }

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -19,7 +19,7 @@ use rustc_hir::{
 };
 use rustc_middle::ty::TyCtxt;
 use rustc_span::def_id::LocalDefId;
-use std::rc::Rc;
+use std::sync::Arc;
 use vir::ast::{Krate, KrateX, VirErr};
 
 fn check_item<'tcx>(
@@ -300,5 +300,5 @@ pub fn crate_to_vir<'tcx>(ctxt: &Context<'tcx>) -> Result<Krate, VirErr> {
     for (id, attr) in attrs {
         check_attr(ctxt.tcx, id, attr)?;
     }
-    Ok(Rc::new(vir))
+    Ok(Arc::new(vir))
 }

--- a/verify/rust_verify/src/rust_to_vir_adts.rs
+++ b/verify/rust_verify/src/rust_to_vir_adts.rs
@@ -6,7 +6,7 @@ use crate::unsupported_unless;
 use crate::util::spanned_new;
 use rustc_hir::{EnumDef, Generics, ItemId, VariantData};
 use rustc_span::Span;
-use std::rc::Rc;
+use std::sync::Arc;
 use vir::ast::{DatatypeX, Ident, KrateX, Mode, Variant, VirErr};
 use vir::ast_util::{ident_binder, str_ident};
 use vir::def::{variant_field_ident, variant_ident, variant_positional_field_ident};
@@ -23,7 +23,7 @@ fn check_variant_data<'tcx>(
         &(match variant_data {
             VariantData::Struct(fields, recovered) => {
                 unsupported_unless!(!recovered, "recovered_struct", variant_data);
-                Rc::new(
+                Arc::new(
                     fields
                         .iter()
                         .map(|field| {
@@ -38,7 +38,7 @@ fn check_variant_data<'tcx>(
                         .collect::<Vec<_>>(),
                 )
             }
-            VariantData::Tuple(fields, _variant_id) => Rc::new(
+            VariantData::Tuple(fields, _variant_id) => Arc::new(
                 fields
                     .iter()
                     .enumerate()
@@ -53,7 +53,7 @@ fn check_variant_data<'tcx>(
                     })
                     .collect::<Vec<_>>(),
             ),
-            VariantData::Unit(_vairant_id) => Rc::new(vec![]),
+            VariantData::Unit(_vairant_id) => Arc::new(vec![]),
         }),
     )
 }
@@ -70,7 +70,7 @@ pub fn check_item_struct<'tcx>(
     let name = hack_get_def_name(ctxt.tcx, id.def_id.to_def_id());
     let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
     let variant_name = variant_ident(&name, &name);
-    let variants = Rc::new(vec![check_variant_data(ctxt, &variant_name, variant_data)]);
+    let variants = Arc::new(vec![check_variant_data(ctxt, &variant_name, variant_data)]);
     vir.datatypes.push(spanned_new(span, DatatypeX { path, variants }));
     Ok(())
 }
@@ -84,9 +84,9 @@ pub fn check_item_enum<'tcx>(
     generics: &'tcx Generics<'tcx>,
 ) -> Result<(), VirErr> {
     check_generics(generics)?;
-    let name = Rc::new(hack_get_def_name(ctxt.tcx, id.def_id.to_def_id()));
+    let name = Arc::new(hack_get_def_name(ctxt.tcx, id.def_id.to_def_id()));
     let path = def_id_to_vir_path(ctxt.tcx, id.def_id.to_def_id());
-    let variants = Rc::new(
+    let variants = Arc::new(
         enum_def
             .variants
             .iter()

--- a/verify/rust_verify/src/util.rs
+++ b/verify/rust_verify/src/util.rs
@@ -1,17 +1,17 @@
 use rustc_span::{Span, SpanData};
-use std::rc::Rc;
+use std::sync::Arc;
 use vir::ast::{VirErr, VirErrX};
 use vir::def::Spanned;
 
 pub(crate) fn to_raw_span(span: Span) -> air::ast::RawSpan {
-    Rc::new(span.data())
+    Arc::new(span.data())
 }
 
 pub(crate) fn from_raw_span(raw_span: &air::ast::RawSpan) -> Span {
     (**raw_span).downcast_ref::<SpanData>().expect("internal error: failed to cast to Span").span()
 }
 
-pub(crate) fn spanned_new<X>(span: Span, x: X) -> Rc<Spanned<X>> {
+pub(crate) fn spanned_new<X>(span: Span, x: X) -> Arc<Spanned<X>> {
     let raw_span = to_raw_span(span);
     let as_string = format!("{:?}", span);
     Spanned::new(air::ast::Span { description: None, raw_span, as_string }, x)

--- a/verify/rust_verify/src/util.rs
+++ b/verify/rust_verify/src/util.rs
@@ -1,14 +1,14 @@
-use rustc_span::Span;
+use rustc_span::{Span, SpanData};
 use std::rc::Rc;
 use vir::ast::{VirErr, VirErrX};
 use vir::def::Spanned;
 
 pub(crate) fn to_raw_span(span: Span) -> air::ast::RawSpan {
-    Rc::new(span)
+    Rc::new(span.data())
 }
 
 pub(crate) fn from_raw_span(raw_span: &air::ast::RawSpan) -> Span {
-    *(**raw_span).downcast_ref::<Span>().expect("internal error: failed to cast to Span")
+    (**raw_span).downcast_ref::<SpanData>().expect("internal error: failed to cast to Span").span()
 }
 
 pub(crate) fn spanned_new<X>(span: Span, x: X) -> Rc<Spanned<X>> {

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -1,18 +1,18 @@
 use crate::def::Spanned;
 use air::ast::Quant;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub use air::ast::{Binder, Binders};
 
-pub type VirErr = Rc<Spanned<VirErrX>>;
+pub type VirErr = Arc<Spanned<VirErrX>>;
 #[derive(Clone, Debug)]
 pub enum VirErrX {
     Str(String),
 }
 
-pub type Ident = Rc<String>;
-pub type Idents = Rc<Vec<Ident>>;
-pub type Path = Rc<Vec<Ident>>;
+pub type Ident = Arc<String>;
+pub type Idents = Arc<Vec<Ident>>;
+pub type Path = Arc<Vec<Ident>>;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Mode {
@@ -31,8 +31,8 @@ pub enum IntRange {
     ISize,
 }
 
-pub type Typ = Rc<TypX>;
-pub type Typs = Rc<Vec<Typ>>;
+pub type Typ = Arc<TypX>;
+pub type Typs = Arc<Vec<Typ>>;
 // Deliberately not marked Eq -- use explicit match instead, so we know where types are compared
 #[derive(Debug)]
 pub enum TypX {
@@ -73,7 +73,7 @@ pub enum BinaryOp {
     EuclideanMod,
 }
 
-pub type HeaderExpr = Rc<HeaderExprX>;
+pub type HeaderExpr = Arc<HeaderExprX>;
 #[derive(Debug)]
 pub enum HeaderExprX {
     Requires(Exprs),
@@ -86,11 +86,11 @@ pub enum HeaderExprX {
 #[derive(Clone, Debug)]
 pub enum Constant {
     Bool(bool),
-    Nat(Rc<String>),
+    Nat(Arc<String>),
 }
 
-pub type Expr = Rc<Spanned<ExprX>>;
-pub type Exprs = Rc<Vec<Expr>>;
+pub type Expr = Arc<Spanned<ExprX>>;
+pub type Exprs = Arc<Vec<Expr>>;
 #[derive(Debug)]
 pub enum ExprX {
     Const(Constant),
@@ -111,16 +111,16 @@ pub enum ExprX {
     Block(Stmts, Option<Expr>),
 }
 
-pub type Stmt = Rc<Spanned<StmtX>>;
-pub type Stmts = Rc<Vec<Stmt>>;
+pub type Stmt = Arc<Spanned<StmtX>>;
+pub type Stmts = Arc<Vec<Stmt>>;
 #[derive(Debug)]
 pub enum StmtX {
     Expr(Expr),
     Decl { param: Param, mutable: bool, init: Option<Expr> },
 }
 
-pub type Param = Rc<Spanned<ParamX>>;
-pub type Params = Rc<Vec<Param>>;
+pub type Param = Arc<Spanned<ParamX>>;
+pub type Params = Arc<Vec<Param>>;
 #[derive(Debug)]
 pub struct ParamX {
     pub name: Ident,
@@ -128,7 +128,7 @@ pub struct ParamX {
     pub mode: Mode,
 }
 
-pub type Function = Rc<Spanned<FunctionX>>;
+pub type Function = Arc<Spanned<FunctionX>>;
 #[derive(Debug, Clone)]
 pub struct FunctionX {
     pub name: Ident,
@@ -154,10 +154,10 @@ pub struct DatatypeX {
     pub path: Path,
     pub variants: Variants,
 }
-pub type Datatype = Rc<Spanned<DatatypeX>>;
+pub type Datatype = Arc<Spanned<DatatypeX>>;
 pub type Datatypes = Vec<Datatype>;
 
-pub type Krate = Rc<KrateX>;
+pub type Krate = Arc<KrateX>;
 #[derive(Debug, Default)]
 pub struct KrateX {
     pub functions: Vec<Function>,

--- a/verify/vir/src/ast_visitor.rs
+++ b/verify/vir/src/ast_visitor.rs
@@ -1,7 +1,7 @@
 use crate::ast::{Expr, ExprX, Stmt, StmtX, VirErr};
 use crate::def::Spanned;
 use crate::util::vec_map_result;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub(crate) fn map_expr_visitor<F>(expr: &Expr, f: &mut F) -> Result<Expr, VirErr>
 where
@@ -17,7 +17,7 @@ where
             }
             let expr = Spanned::new(
                 expr.span.clone(),
-                ExprX::Call(x.clone(), typs.clone(), Rc::new(exprs)),
+                ExprX::Call(x.clone(), typs.clone(), Arc::new(exprs)),
             );
             f(&expr)
         }
@@ -28,7 +28,7 @@ where
                 .collect::<Result<Vec<_>, _>>()?;
             let expr = Spanned::new(
                 expr.span.clone(),
-                ExprX::Ctor(path.clone(), ident.clone(), Rc::new(mapped_binders)),
+                ExprX::Ctor(path.clone(), ident.clone(), Arc::new(mapped_binders)),
             );
             f(&expr)
         }
@@ -85,7 +85,7 @@ where
         ExprX::While { cond, body, invs } => {
             let cond = map_expr_visitor(cond, f)?;
             let body = map_expr_visitor(body, f)?;
-            let invs = Rc::new(vec_map_result(invs, |e| map_expr_visitor(e, f))?);
+            let invs = Arc::new(vec_map_result(invs, |e| map_expr_visitor(e, f))?);
             let expr = Spanned::new(expr.span.clone(), ExprX::While { cond, body, invs });
             f(&expr)
         }
@@ -98,7 +98,7 @@ where
                 None => None,
                 Some(e) => Some(map_expr_visitor(e, f)?),
             };
-            let expr = Spanned::new(expr.span.clone(), ExprX::Block(Rc::new(exprs), expr1));
+            let expr = Spanned::new(expr.span.clone(), ExprX::Block(Arc::new(exprs), expr1));
             f(&expr)
         }
     }

--- a/verify/vir/src/context.rs
+++ b/verify/vir/src/context.rs
@@ -4,7 +4,7 @@ use crate::scc::Graph;
 use air::ast::{Command, CommandX, Commands, DeclX, MultiOp, Span};
 use air::ast_util::str_typ;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub struct Ctx {
     pub(crate) datatypes: HashMap<Path, Variants>,
@@ -50,16 +50,16 @@ impl Ctx {
                     let id = crate::def::prefix_fuel_id(&function.x.name);
                     ids.push(air::ast_util::ident_var(&id));
                     let typ_fuel_id = str_typ(&FUEL_ID);
-                    let decl = Rc::new(DeclX::Const(id, typ_fuel_id));
-                    commands.push(Rc::new(CommandX::Global(decl)));
+                    let decl = Arc::new(DeclX::Const(id, typ_fuel_id));
+                    commands.push(Arc::new(CommandX::Global(decl)));
                 }
                 _ => {}
             }
         }
-        let distinct = Rc::new(air::ast::ExprX::Multi(MultiOp::Distinct, Rc::new(ids)));
-        let decl = Rc::new(DeclX::Axiom(distinct));
-        commands.push(Rc::new(CommandX::Global(decl)));
-        Rc::new(commands)
+        let distinct = Arc::new(air::ast::ExprX::Multi(MultiOp::Distinct, Arc::new(ids)));
+        let decl = Arc::new(DeclX::Axiom(distinct));
+        commands.push(Arc::new(CommandX::Global(decl)));
+        Arc::new(commands)
     }
 
     // Report chosen triggers as strings for printing diagnostics

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -1,6 +1,6 @@
 use air::ast::{Ident, Span};
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /*
 In SMT-LIB format (used by Z3), symbols are built of letters, digits, and:
@@ -78,59 +78,59 @@ pub const HAS_TYPE: &str = "has_type";
 pub const VARIANT_FIELD_SEPARATOR: &str = "/";
 
 pub fn suffix_global_id(ident: &Ident) -> Ident {
-    Rc::new(ident.to_string() + SUFFIX_GLOBAL)
+    Arc::new(ident.to_string() + SUFFIX_GLOBAL)
 }
 
 pub fn suffix_local_id(ident: &Ident) -> Ident {
-    Rc::new(ident.to_string() + SUFFIX_LOCAL)
+    Arc::new(ident.to_string() + SUFFIX_LOCAL)
 }
 
 pub fn suffix_typ_param_id(ident: &Ident) -> Ident {
-    Rc::new(ident.to_string() + SUFFIX_TYPE_PARAM)
+    Arc::new(ident.to_string() + SUFFIX_TYPE_PARAM)
 }
 
 pub fn suffix_rename(ident: &Ident) -> Ident {
-    Rc::new(ident.to_string() + SUFFIX_RENAME)
+    Arc::new(ident.to_string() + SUFFIX_RENAME)
 }
 
 pub fn prefix_type_id(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_TYPE_ID.to_string() + ident)
+    Arc::new(PREFIX_TYPE_ID.to_string() + ident)
 }
 
 pub fn prefix_box(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_BOX.to_string() + ident)
+    Arc::new(PREFIX_BOX.to_string() + ident)
 }
 
 pub fn prefix_unbox(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_UNBOX.to_string() + ident)
+    Arc::new(PREFIX_UNBOX.to_string() + ident)
 }
 
 pub fn prefix_fuel_id(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_FUEL_ID.to_string() + ident)
+    Arc::new(PREFIX_FUEL_ID.to_string() + ident)
 }
 
 pub fn prefix_fuel_nat(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_FUEL_NAT.to_string() + ident)
+    Arc::new(PREFIX_FUEL_NAT.to_string() + ident)
 }
 
 pub fn prefix_requires(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_REQUIRES.to_string() + ident)
+    Arc::new(PREFIX_REQUIRES.to_string() + ident)
 }
 
 pub fn prefix_ensures(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_ENSURES.to_string() + ident)
+    Arc::new(PREFIX_ENSURES.to_string() + ident)
 }
 
 pub fn prefix_recursive(ident: &Ident) -> Ident {
-    Rc::new(PREFIX_RECURSIVE.to_string() + ident)
+    Arc::new(PREFIX_RECURSIVE.to_string() + ident)
 }
 
 pub fn variant_ident(adt_name: &str, variant_name: &str) -> Ident {
-    Rc::new(format!("{}{}{}", adt_name, VARIANT_SEPARATOR, variant_name))
+    Arc::new(format!("{}{}{}", adt_name, VARIANT_SEPARATOR, variant_name))
 }
 
 pub fn variant_field_ident(variant_ident: &Ident, name: &str) -> Ident {
-    Rc::new(format!("{}{}{}", variant_ident.as_str(), VARIANT_FIELD_SEPARATOR, name))
+    Arc::new(format!("{}{}{}", variant_ident.as_str(), VARIANT_FIELD_SEPARATOR, name))
 }
 
 #[inline(always)]
@@ -144,8 +144,8 @@ pub struct Spanned<X> {
 }
 
 impl<X> Spanned<X> {
-    pub fn new(span: Span, x: X) -> Rc<Spanned<X>> {
-        Rc::new(Spanned { span: span, x: x })
+    pub fn new(span: Span, x: X) -> Arc<Spanned<X>> {
+        Arc::new(Spanned { span: span, x: x })
     }
 }
 

--- a/verify/vir/src/headers.rs
+++ b/verify/vir/src/headers.rs
@@ -1,7 +1,7 @@
 use crate::ast::{Expr, ExprX, Exprs, HeaderExprX, Ident, Stmt, StmtX, Typ, VirErr};
 use crate::ast_util::err_str;
 use crate::def::Spanned;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct Header {
@@ -71,12 +71,12 @@ fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
         n += 1;
     }
     *block = block[n..].to_vec();
-    let require = require.unwrap_or(Rc::new(vec![]));
+    let require = require.unwrap_or(Arc::new(vec![]));
     let (ensure_id_typ, ensure) = match ensure {
-        None => (None, Rc::new(vec![])),
+        None => (None, Arc::new(vec![])),
         Some((id_typ, es)) => (id_typ, es),
     };
-    let invariant = invariant.unwrap_or(Rc::new(vec![]));
+    let invariant = invariant.unwrap_or(Arc::new(vec![]));
     Ok(Header { hidden, require, ensure_id_typ, ensure, invariant, decrease })
 }
 
@@ -85,7 +85,7 @@ pub fn read_header(body: &mut Expr) -> Result<Header, VirErr> {
         ExprX::Block(stmts, expr) => {
             let mut block: Vec<Stmt> = (**stmts).clone();
             let header = read_header_block(&mut block)?;
-            *body = Spanned::new(body.span.clone(), ExprX::Block(Rc::new(block), expr.clone()));
+            *body = Spanned::new(body.span.clone(), ExprX::Block(Arc::new(block), expr.clone()));
             Ok(header)
         }
         _ => read_header_block(&mut vec![]),

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -8,12 +8,12 @@ sst expressions cannot contain statments.
 use crate::ast::{BinaryOp, Path, Typ, Typs, UnaryOp, UnaryOpr};
 use crate::def::Spanned;
 use air::ast::{Binders, Ident, Quant};
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub type Trig = Exps;
-pub type Trigs = Rc<Vec<Trig>>;
+pub type Trigs = Arc<Vec<Trig>>;
 
-pub type Bnd = Rc<Spanned<BndX>>;
+pub type Bnd = Arc<Spanned<BndX>>;
 #[derive(Clone, Debug)]
 pub enum BndX {
     Let(Binders<Exp>),
@@ -23,11 +23,11 @@ pub enum BndX {
 #[derive(Clone, Debug)]
 pub enum Constant {
     Bool(bool),
-    Nat(Rc<String>),
+    Nat(Arc<String>),
 }
 
-pub type Exp = Rc<Spanned<ExpX>>;
-pub type Exps = Rc<Vec<Exp>>;
+pub type Exp = Arc<Spanned<ExpX>>;
+pub type Exps = Arc<Vec<Exp>>;
 #[derive(Debug)]
 pub enum ExpX {
     Const(Constant),
@@ -49,8 +49,8 @@ pub struct Dest {
     pub mutable: bool,
 }
 
-pub type Stm = Rc<Spanned<StmX>>;
-pub type Stms = Rc<Vec<Stm>>;
+pub type Stm = Arc<Spanned<StmX>>;
+pub type Stms = Arc<Vec<Stm>>;
 #[derive(Debug)]
 pub enum StmX {
     Call(Ident, Typs, Exps, Option<Dest>), // call to exec/proof function
@@ -69,8 +69,8 @@ pub enum StmX {
         cond: Exp,
         body: Stm,
         invs: Exps,
-        typ_inv_vars: Rc<Vec<(Ident, Typ)>>,
-        modified_vars: Rc<Vec<Ident>>,
+        typ_inv_vars: Arc<Vec<(Ident, Typ)>>,
+        modified_vars: Arc<Vec<Ident>>,
     },
     Block(Stms),
 }

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -19,11 +19,11 @@ use air::ast_util::{
     mk_implies, mk_ite, mk_not, mk_or, str_apply, str_ident, str_typ, str_var, string_var,
 };
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[inline(always)]
 pub(crate) fn path_to_air_ident(path: &Path) -> Ident {
-    Rc::new(path_to_string(path))
+    Arc::new(path_to_string(path))
 }
 
 pub(crate) fn apply_range_fun(name: &str, range: &IntRange, exprs: Vec<Expr>) -> Expr {
@@ -31,8 +31,8 @@ pub(crate) fn apply_range_fun(name: &str, range: &IntRange, exprs: Vec<Expr>) ->
     match range {
         IntRange::Int | IntRange::Nat => {}
         IntRange::U(range) | IntRange::I(range) => {
-            let bits = Constant::Nat(Rc::new(range.to_string()));
-            args.insert(0, Rc::new(ExprX::Const(bits)));
+            let bits = Constant::Nat(Arc::new(range.to_string()));
+            args.insert(0, Arc::new(ExprX::Const(bits)));
         }
         IntRange::USize | IntRange::ISize => {
             args.insert(0, str_var(crate::def::ARCH_SIZE));
@@ -63,7 +63,7 @@ pub fn typ_to_id(typ: &Typ) -> Expr {
             }
         },
         TypX::Bool => str_var(crate::def::TYPE_ID_BOOL),
-        TypX::Path(path) => string_var(&prefix_type_id(&Rc::new(path_to_string(&path)))),
+        TypX::Path(path) => string_var(&prefix_type_id(&Arc::new(path_to_string(&path)))),
         TypX::TypParam(x) => ident_var(&suffix_typ_param_id(x)),
     }
 }
@@ -73,8 +73,8 @@ pub(crate) fn typ_invariant(typ: &Typ, expr: &Expr, use_has_type: bool) -> Optio
     match &**typ {
         TypX::Int(IntRange::Int) => None,
         TypX::Int(IntRange::Nat) => {
-            let zero = Rc::new(ExprX::Const(Constant::Nat(Rc::new("0".to_string()))));
-            Some(Rc::new(ExprX::Binary(air::ast::BinaryOp::Le, zero, expr.clone())))
+            let zero = Arc::new(ExprX::Const(Constant::Nat(Arc::new("0".to_string()))));
+            Some(Arc::new(ExprX::Binary(air::ast::BinaryOp::Le, zero, expr.clone())))
         }
         TypX::Int(range) => {
             let f_name = match range {
@@ -98,7 +98,7 @@ pub(crate) fn ctor_to_apply<'a>(
     path: &Path,
     variant: &Ident,
     binders: &'a Binders<Exp>,
-) -> (Ident, impl Iterator<Item = &'a Rc<BinderX<Rc<Spanned<ExpX>>>>>) {
+) -> (Ident, impl Iterator<Item = &'a Arc<BinderX<Arc<Spanned<ExpX>>>>>) {
     let fields = &ctx.datatypes[path]
         .iter()
         .find(|v| &v.name == variant)
@@ -117,8 +117,8 @@ pub(crate) fn ctor_to_apply<'a>(
 
 pub(crate) fn constant_to_expr(_ctx: &Ctx, constant: &crate::sst::Constant) -> Expr {
     match constant {
-        crate::sst::Constant::Bool(b) => Rc::new(ExprX::Const(Constant::Bool(*b))),
-        crate::sst::Constant::Nat(s) => Rc::new(ExprX::Const(Constant::Nat(s.clone()))),
+        crate::sst::Constant::Bool(b) => Arc::new(ExprX::Const(Constant::Bool(*b))),
+        crate::sst::Constant::Nat(s) => Arc::new(ExprX::Const(Constant::Nat(s.clone()))),
     }
 }
 
@@ -129,7 +129,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
             expr
         }
         ExpX::Var(x) => string_var(&suffix_local_id(x)),
-        ExpX::Old(span, x) => Rc::new(ExprX::Old(span.clone(), suffix_local_id(x))),
+        ExpX::Old(span, x) => Arc::new(ExprX::Old(span.clone(), suffix_local_id(x))),
         ExpX::Call(x, typs, args) => {
             let name = suffix_global_id(&x);
             let mut exprs: Vec<Expr> = vec_map(typs, typ_to_id);
@@ -141,7 +141,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
         ExpX::Ctor(path, variant, binders) => {
             let (variant, args) = ctor_to_apply(ctx, path, variant, binders);
             let args = args.map(|b| exp_to_expr(ctx, &b.a)).collect::<Vec<_>>();
-            Rc::new(ExprX::Apply(variant, Rc::new(args)))
+            Arc::new(ExprX::Apply(variant, Arc::new(args)))
         }
         ExpX::Unary(op, exp) => match op {
             UnaryOp::Not => mk_not(&exp_to_expr(ctx, exp)),
@@ -164,7 +164,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                 let f_name = match &**typ {
                     TypX::Bool => str_ident(crate::def::BOX_BOOL),
                     TypX::Int(_) => str_ident(crate::def::BOX_INT),
-                    TypX::Path(path) => crate::def::prefix_box(&Rc::new(path_to_string(&path))),
+                    TypX::Path(path) => crate::def::prefix_box(&Arc::new(path_to_string(&path))),
                     TypX::TypParam(_) => panic!("internal error: Box(TypParam)"),
                 };
                 ident_apply(&f_name, &vec![expr])
@@ -174,7 +174,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                 let f_name = match &**typ {
                     TypX::Bool => str_ident(crate::def::UNBOX_BOOL),
                     TypX::Int(_) => str_ident(crate::def::UNBOX_INT),
-                    TypX::Path(path) => crate::def::prefix_unbox(&Rc::new(path_to_string(&path))),
+                    TypX::Path(path) => crate::def::prefix_unbox(&Arc::new(path_to_string(&path))),
                     TypX::TypParam(_) => panic!("internal error: Box(TypParam)"),
                 };
                 ident_apply(&f_name, &vec![expr])
@@ -193,12 +193,12 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                 BinaryOp::Implies => {
                     return mk_implies(&lh, &rh);
                 }
-                BinaryOp::Add => ExprX::Multi(MultiOp::Add, Rc::new(vec![lh, rh])),
-                BinaryOp::Sub => ExprX::Multi(MultiOp::Sub, Rc::new(vec![lh, rh])),
-                BinaryOp::Mul => ExprX::Multi(MultiOp::Mul, Rc::new(vec![lh, rh])),
+                BinaryOp::Add => ExprX::Multi(MultiOp::Add, Arc::new(vec![lh, rh])),
+                BinaryOp::Sub => ExprX::Multi(MultiOp::Sub, Arc::new(vec![lh, rh])),
+                BinaryOp::Mul => ExprX::Multi(MultiOp::Mul, Arc::new(vec![lh, rh])),
                 BinaryOp::Ne => {
                     let eq = ExprX::Binary(air::ast::BinaryOp::Eq, lh, rh);
-                    ExprX::Unary(air::ast::UnaryOp::Not, Rc::new(eq))
+                    ExprX::Unary(air::ast::UnaryOp::Not, Arc::new(eq))
                 }
                 _ => {
                     let aop = match op {
@@ -220,7 +220,7 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                     ExprX::Binary(aop, lh, rh)
                 }
             };
-            Rc::new(expx)
+            Arc::new(expx)
         }
         ExpX::If(e1, e2, e3) => {
             mk_ite(&exp_to_expr(ctx, e1), &exp_to_expr(ctx, e2), &exp_to_expr(ctx, e3))
@@ -228,15 +228,15 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
         ExpX::Field { lhs, datatype_name: _, field_name: name } => {
             // TODO: this should include datatype_name in the function name
             let lh = exp_to_expr(ctx, lhs);
-            Rc::new(ExprX::Apply(name.clone(), Rc::new(vec![lh])))
+            Arc::new(ExprX::Apply(name.clone(), Arc::new(vec![lh])))
         }
         ExpX::Bind(bnd, exp) => match &bnd.x {
             BndX::Let(binders) => {
                 let expr = exp_to_expr(ctx, exp);
                 let binders = vec_map(&*binders, |b| {
-                    Rc::new(BinderX { name: suffix_local_id(&b.name), a: exp_to_expr(ctx, &b.a) })
+                    Arc::new(BinderX { name: suffix_local_id(&b.name), a: exp_to_expr(ctx, &b.a) })
                 });
-                Rc::new(ExprX::Bind(Rc::new(BindX::Let(Rc::new(binders))), expr))
+                Arc::new(ExprX::Bind(Arc::new(BindX::Let(Arc::new(binders))), expr))
             }
             BndX::Quant(quant, binders, trigs) => {
                 let expr = exp_to_expr(ctx, exp);
@@ -254,12 +254,12 @@ pub(crate) fn exp_to_expr(ctx: &Ctx, exp: &Exp) -> Expr {
                     Quant::Exists => mk_and(&vec![inv, expr]),
                 };
                 let binders = vec_map(&*binders, |b| {
-                    Rc::new(BinderX { name: suffix_local_id(&b.name), a: typ_to_air(&b.a) })
+                    Arc::new(BinderX { name: suffix_local_id(&b.name), a: typ_to_air(&b.a) })
                 });
                 let triggers =
-                    vec_map(&*trigs, |trig| Rc::new(vec_map(trig, |x| exp_to_expr(ctx, x))));
-                Rc::new(ExprX::Bind(
-                    Rc::new(BindX::Quant(*quant, Rc::new(binders), Rc::new(triggers))),
+                    vec_map(&*trigs, |trig| Arc::new(vec_map(trig, |x| exp_to_expr(ctx, x))));
+                Arc::new(ExprX::Bind(
+                    Arc::new(BindX::Quant(*quant, Arc::new(binders), Arc::new(triggers))),
                     expr,
                 ))
             }
@@ -284,10 +284,10 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 for arg in args.iter() {
                     req_args.push(exp_to_expr(ctx, arg));
                 }
-                let e_req = Rc::new(ExprX::Apply(f_req, Rc::new(req_args)));
+                let e_req = Arc::new(ExprX::Apply(f_req, Arc::new(req_args)));
                 let description = Some("precondition not satisfied".to_string());
-                let option_span = Rc::new(Some(Span { description, ..stm.span.clone() }));
-                stmts.push(Rc::new(StmtX::Assert(option_span, e_req)));
+                let option_span = Arc::new(Some(Span { description, ..stm.span.clone() }));
+                stmts.push(Arc::new(StmtX::Assert(option_span, e_req)));
             }
             let mut ens_args: Vec<Expr> = vec_map(typs, typ_to_id);
             match dest {
@@ -313,40 +313,40 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                         ens_args.push(exp_to_expr(ctx, &arg_x));
                     }
                     if overwrite {
-                        stmts.push(Rc::new(StmtX::Snapshot(str_ident(SNAPSHOT_CALL))));
+                        stmts.push(Arc::new(StmtX::Snapshot(str_ident(SNAPSHOT_CALL))));
                     }
-                    ens_args.push(Rc::new(ExprX::Var(x.clone())));
+                    ens_args.push(Arc::new(ExprX::Var(x.clone())));
                     if *mutable {
                         let havoc = StmtX::Havoc(x.clone());
-                        stmts.push(Rc::new(havoc));
+                        stmts.push(Arc::new(havoc));
                     }
                     if ctx.debug {
                         // Add a snapshot after we modify the destination
                         state.snapshot_count += 1;
                         let name = format!("Mutation_{}", state.snapshot_count);
-                        let snapshot = Rc::new(StmtX::Snapshot(Rc::new(name)));
+                        let snapshot = Arc::new(StmtX::Snapshot(Arc::new(name)));
                         stmts.push(snapshot);
                     }
                 }
             }
             if func.x.ensure.len() > 0 {
                 let f_ens = prefix_ensures(&func.x.name);
-                let e_ens = Rc::new(ExprX::Apply(f_ens, Rc::new(ens_args)));
-                stmts.push(Rc::new(StmtX::Assume(e_ens)));
+                let e_ens = Arc::new(ExprX::Apply(f_ens, Arc::new(ens_args)));
+                stmts.push(Arc::new(StmtX::Assume(e_ens)));
             }
-            vec![Rc::new(StmtX::Block(Rc::new(stmts)))] // wrap in block for readability
+            vec![Arc::new(StmtX::Block(Arc::new(stmts)))] // wrap in block for readability
         }
         StmX::Assert(expr) => {
             let air_expr = exp_to_expr(ctx, &expr);
-            let option_span = Rc::new(Some(stm.span.clone()));
-            vec![Rc::new(StmtX::Assert(option_span, air_expr))]
+            let option_span = Arc::new(Some(stm.span.clone()));
+            vec![Arc::new(StmtX::Assert(option_span, air_expr))]
         }
-        StmX::Assume(expr) => vec![Rc::new(StmtX::Assume(exp_to_expr(ctx, &expr)))],
+        StmX::Assume(expr) => vec![Arc::new(StmtX::Assume(exp_to_expr(ctx, &expr)))],
         StmX::Decl { ident, typ, mutable, init: _ } => {
             state.local_shared.push(if *mutable {
-                Rc::new(DeclX::Var(suffix_local_id(&ident), typ_to_air(&typ)))
+                Arc::new(DeclX::Var(suffix_local_id(&ident), typ_to_air(&typ)))
             } else {
-                Rc::new(DeclX::Const(suffix_local_id(&ident), typ_to_air(&typ)))
+                Arc::new(DeclX::Const(suffix_local_id(&ident), typ_to_air(&typ)))
             });
             vec![]
         }
@@ -356,21 +356,21 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 ExpX::Var(ident) => ident,
                 _ => panic!("unexpected lhs {:?} in assign", lhs),
             };
-            stmts.push(Rc::new(StmtX::Assign(suffix_local_id(&ident), exp_to_expr(ctx, rhs))));
+            stmts.push(Arc::new(StmtX::Assign(suffix_local_id(&ident), exp_to_expr(ctx, rhs))));
             if ctx.debug {
                 // Add a snapshot after we modify the destination
                 state.snapshot_count += 1;
                 let name = format!("Mutation_{}", state.snapshot_count);
-                let snapshot = Rc::new(StmtX::Snapshot(Rc::new(name)));
+                let snapshot = Arc::new(StmtX::Snapshot(Arc::new(name)));
                 stmts.push(snapshot);
             }
             stmts
         }
         StmX::If(cond, lhs, rhs) => {
             let pos_cond = exp_to_expr(ctx, &cond);
-            let neg_cond = Rc::new(ExprX::Unary(air::ast::UnaryOp::Not, pos_cond.clone()));
-            let pos_assume = Rc::new(StmtX::Assume(pos_cond));
-            let neg_assume = Rc::new(StmtX::Assume(neg_cond));
+            let neg_cond = Arc::new(ExprX::Unary(air::ast::UnaryOp::Not, pos_cond.clone()));
+            let pos_assume = Arc::new(StmtX::Assume(pos_cond));
+            let neg_assume = Arc::new(StmtX::Assume(neg_cond));
             let mut lhss = stm_to_stmts(ctx, state, lhs);
             let mut rhss = match rhs {
                 None => vec![],
@@ -378,15 +378,15 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             };
             lhss.insert(0, pos_assume);
             rhss.insert(0, neg_assume);
-            let lblock = Rc::new(StmtX::Block(Rc::new(lhss)));
-            let rblock = Rc::new(StmtX::Block(Rc::new(rhss)));
-            vec![Rc::new(StmtX::Switch(Rc::new(vec![lblock, rblock])))]
+            let lblock = Arc::new(StmtX::Block(Arc::new(lhss)));
+            let rblock = Arc::new(StmtX::Block(Arc::new(rhss)));
+            vec![Arc::new(StmtX::Switch(Arc::new(vec![lblock, rblock])))]
         }
         StmX::While { cond, body, invs, typ_inv_vars, modified_vars } => {
             let pos_cond = exp_to_expr(ctx, &cond);
-            let neg_cond = Rc::new(ExprX::Unary(air::ast::UnaryOp::Not, pos_cond.clone()));
-            let pos_assume = Rc::new(DeclX::Axiom(pos_cond));
-            let neg_assume = Rc::new(StmtX::Assume(neg_cond));
+            let neg_cond = Arc::new(ExprX::Unary(air::ast::UnaryOp::Not, pos_cond.clone()));
+            let pos_assume = Arc::new(DeclX::Axiom(pos_cond));
+            let neg_assume = Arc::new(StmtX::Assume(neg_cond));
             let invs: Vec<(Span, Expr)> =
                 invs.iter().map(|e| (e.span.clone(), exp_to_expr(ctx, e))).collect();
             let mut air_body = stm_to_stmts(ctx, state, body);
@@ -412,49 +412,49 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
             for (x, typ) in typ_inv_vars.iter() {
                 let typ_inv = typ_invariant(typ, &ident_var(&suffix_local_id(x)), false);
                 if let Some(expr) = typ_inv {
-                    local.push(Rc::new(DeclX::Axiom(expr)));
+                    local.push(Arc::new(DeclX::Axiom(expr)));
                 }
             }
             for (_, inv) in invs.iter() {
-                local.push(Rc::new(DeclX::Axiom(inv.clone())));
+                local.push(Arc::new(DeclX::Axiom(inv.clone())));
             }
             local.push(pos_assume);
             for (span, inv) in invs.iter() {
                 let description = Some("invariant not satisfied at end of loop body".to_string());
-                let option_span = Rc::new(Some(Span { description, ..span.clone() }));
+                let option_span = Arc::new(Some(Span { description, ..span.clone() }));
                 let inv_stmt = StmtX::Assert(option_span, inv.clone());
-                air_body.push(Rc::new(inv_stmt));
+                air_body.push(Arc::new(inv_stmt));
             }
             let assertion = if air_body.len() == 1 {
                 air_body[0].clone()
             } else {
-                Rc::new(StmtX::Block(Rc::new(air_body)))
+                Arc::new(StmtX::Block(Arc::new(air_body)))
             };
-            let query = Rc::new(QueryX { local: Rc::new(local), assertion });
-            state.commands.push(Rc::new(CommandX::CheckValid(query)));
+            let query = Arc::new(QueryX { local: Arc::new(local), assertion });
+            state.commands.push(Arc::new(CommandX::CheckValid(query)));
 
             // At original site of while loop, assert invariant, havoc, assume invariant + neg_cond
             let mut stmts: Vec<Stmt> = Vec::new();
             for (span, inv) in invs.iter() {
                 let description = Some("invariant not satisfied before loop".to_string());
-                let option_span = Rc::new(Some(Span { description, ..span.clone() }));
+                let option_span = Arc::new(Some(Span { description, ..span.clone() }));
                 let inv_stmt = StmtX::Assert(option_span, inv.clone());
-                stmts.push(Rc::new(inv_stmt));
+                stmts.push(Arc::new(inv_stmt));
             }
             for x in modified_vars.iter() {
-                stmts.push(Rc::new(StmtX::Havoc(suffix_local_id(&x))));
+                stmts.push(Arc::new(StmtX::Havoc(suffix_local_id(&x))));
             }
             for (x, typ) in typ_inv_vars.iter() {
                 if modified_vars.contains(x) {
                     let typ_inv = typ_invariant(typ, &ident_var(&suffix_local_id(x)), false);
                     if let Some(expr) = typ_inv {
-                        stmts.push(Rc::new(StmtX::Assume(expr)));
+                        stmts.push(Arc::new(StmtX::Assume(expr)));
                     }
                 }
             }
             for (_, inv) in invs.iter() {
                 let inv_stmt = StmtX::Assume(inv.clone());
-                stmts.push(Rc::new(inv_stmt));
+                stmts.push(Arc::new(inv_stmt));
             }
             stmts.push(neg_assume);
             stmts
@@ -465,7 +465,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 // (assume (fuel_bool fuel%f))
                 let id_fuel = prefix_fuel_id(&x);
                 let expr_fuel_bool = str_apply(&FUEL_BOOL, &vec![ident_var(&id_fuel)]);
-                stmts.push(Rc::new(StmtX::Assume(expr_fuel_bool)));
+                stmts.push(Arc::new(StmtX::Assume(expr_fuel_bool)));
             }
             if *fuel >= 2 {
                 // (assume (exists ((fuel Fuel)) (= fuel_nat%f (succ ... succ fuel))))
@@ -475,7 +475,7 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                 }
                 let eq = mk_eq(&ident_var(&crate::def::prefix_fuel_nat(&x)), &added_fuel);
                 let binder = ident_binder(&str_ident(FUEL_PARAM), &str_typ(FUEL_TYPE));
-                stmts.push(Rc::new(StmtX::Assume(mk_exists(&vec![binder], &vec![], &eq))));
+                stmts.push(Arc::new(StmtX::Assume(mk_exists(&vec![binder], &vec![], &eq))));
             }
             stmts
         }
@@ -495,23 +495,23 @@ fn set_fuel(local: &mut Vec<Decl>, hidden: &Vec<Ident>) {
         let fuel_bool = str_apply(&FUEL_BOOL, &vec![x_id.clone()]);
         let fuel_bool_default = str_apply(&FUEL_BOOL_DEFAULT, &vec![x_id.clone()]);
         let eq = air::ast::BinaryOp::Eq;
-        disjuncts.push(Rc::new(ExprX::Binary(eq, fuel_bool.clone(), fuel_bool_default)));
+        disjuncts.push(Arc::new(ExprX::Binary(eq, fuel_bool.clone(), fuel_bool_default)));
 
         // ... || id == hidden1 || id == hidden2 || ...
         for hide in hidden {
             let x_hide = ident_var(&prefix_fuel_id(&hide));
-            disjuncts.push(Rc::new(ExprX::Binary(air::ast::BinaryOp::Eq, x_id.clone(), x_hide)));
+            disjuncts.push(Arc::new(ExprX::Binary(air::ast::BinaryOp::Eq, x_id.clone(), x_hide)));
         }
 
         // (forall ((id FuelId)) ...)
-        let trigger: Trigger = Rc::new(vec![fuel_bool.clone()]);
-        let triggers: Triggers = Rc::new(vec![trigger]);
-        let binders: Binders<air::ast::Typ> = Rc::new(vec![ident_binder(&id, &str_typ(FUEL_ID))]);
-        let bind = Rc::new(BindX::Quant(Quant::Forall, binders, triggers));
-        let or = Rc::new(ExprX::Multi(air::ast::MultiOp::Or, Rc::new(disjuncts)));
-        Rc::new(ExprX::Bind(bind, or))
+        let trigger: Trigger = Arc::new(vec![fuel_bool.clone()]);
+        let triggers: Triggers = Arc::new(vec![trigger]);
+        let binders: Binders<air::ast::Typ> = Arc::new(vec![ident_binder(&id, &str_typ(FUEL_ID))]);
+        let bind = Arc::new(BindX::Quant(Quant::Forall, binders, triggers));
+        let or = Arc::new(ExprX::Multi(air::ast::MultiOp::Or, Arc::new(disjuncts)));
+        Arc::new(ExprX::Bind(bind, or))
     };
-    local.push(Rc::new(DeclX::Axiom(fuel_expr)));
+    local.push(Arc::new(DeclX::Axiom(fuel_expr)));
 }
 
 pub fn body_stm_to_air(
@@ -530,16 +530,16 @@ pub fn body_stm_to_air(
     let mut local_shared: Vec<Decl> = Vec::new();
     for x in typ_params.iter() {
         local_shared
-            .push(Rc::new(DeclX::Const(suffix_typ_param_id(&x), str_typ(crate::def::TYPE))));
+            .push(Arc::new(DeclX::Const(suffix_typ_param_id(&x), str_typ(crate::def::TYPE))));
     }
     for param in params.iter() {
         local_shared
-            .push(Rc::new(DeclX::Const(suffix_local_id(&param.x.name), typ_to_air(&param.x.typ))));
+            .push(Arc::new(DeclX::Const(suffix_local_id(&param.x.name), typ_to_air(&param.x.typ))));
     }
     match ret {
         None => {}
         Some((x, typ, _)) => {
-            local_shared.push(Rc::new(DeclX::Const(suffix_local_id(&x), typ_to_air(&typ))));
+            local_shared.push(Arc::new(DeclX::Const(suffix_local_id(&x), typ_to_air(&typ))));
         }
     }
 
@@ -558,7 +558,7 @@ pub fn body_stm_to_air(
     let mut stmts = stm_to_stmts(ctx, &mut state, &stm);
 
     if ctx.debug {
-        let snapshot = Rc::new(StmtX::Snapshot(Rc::new("Entry".to_string())));
+        let snapshot = Arc::new(StmtX::Snapshot(Arc::new("Entry".to_string())));
         let mut new_stmts = vec![snapshot];
         new_stmts.append(&mut stmts);
         stmts = new_stmts;
@@ -568,26 +568,26 @@ pub fn body_stm_to_air(
 
     for ens in enss {
         let description = Some("postcondition not satisfied".to_string());
-        let option_span = Rc::new(Some(Span { description, ..ens.span.clone() }));
+        let option_span = Arc::new(Some(Span { description, ..ens.span.clone() }));
         let ens_stmt = StmtX::Assert(option_span, exp_to_expr(ctx, ens));
-        stmts.push(Rc::new(ens_stmt));
+        stmts.push(Arc::new(ens_stmt));
     }
     let assertion =
-        if stmts.len() == 1 { stmts[0].clone() } else { Rc::new(StmtX::Block(Rc::new(stmts))) };
+        if stmts.len() == 1 { stmts[0].clone() } else { Arc::new(StmtX::Block(Arc::new(stmts))) };
 
     for param in params.iter() {
         let typ_inv =
             typ_invariant(&param.x.typ, &ident_var(&suffix_local_id(&param.x.name)), false);
         if let Some(expr) = typ_inv {
-            local.push(Rc::new(DeclX::Axiom(expr)));
+            local.push(Arc::new(DeclX::Axiom(expr)));
         }
     }
 
     for req in reqs {
-        local.push(Rc::new(DeclX::Axiom(exp_to_expr(ctx, req))));
+        local.push(Arc::new(DeclX::Axiom(exp_to_expr(ctx, req))));
     }
 
-    let query = Rc::new(QueryX { local: Rc::new(local), assertion });
-    state.commands.push(Rc::new(CommandX::CheckValid(query)));
-    Rc::new(state.commands)
+    let query = Arc::new(QueryX { local: Arc::new(local), assertion });
+    state.commands.push(Arc::new(CommandX::CheckValid(query)));
+    Arc::new(state.commands)
 }

--- a/verify/vir/src/sst_vars.rs
+++ b/verify/vir/src/sst_vars.rs
@@ -2,7 +2,7 @@ use crate::ast::{Ident, Typ};
 use crate::def::Spanned;
 use crate::sst::{ExpX, Stm, StmX};
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::sync::Arc;
 
 // Compute:
 // - which variables have definitely been assigned to up to each statement
@@ -92,8 +92,8 @@ pub(crate) fn stm_assign(
                 cond: cond.clone(),
                 body,
                 invs: invs.clone(),
-                typ_inv_vars: Rc::new(typ_inv_vars),
-                modified_vars: Rc::new(modified_vars),
+                typ_inv_vars: Arc::new(typ_inv_vars),
+                modified_vars: Arc::new(modified_vars),
             };
             Spanned::new(stm.span.clone(), while_x)
         }
@@ -109,7 +109,7 @@ pub(crate) fn stm_assign(
             }
             *assigned = pre_assigned;
             *declared = pre_declared;
-            Spanned::new(stm.span.clone(), StmX::Block(Rc::new(stms)))
+            Spanned::new(stm.span.clone(), StmX::Block(Arc::new(stms)))
         }
     }
 }

--- a/verify/vir/src/triggers.rs
+++ b/verify/vir/src/triggers.rs
@@ -4,7 +4,7 @@ use crate::context::Ctx;
 use crate::sst::{Bnd, BndX, Exp, ExpX, Trig, Trigs};
 use air::ast::Span;
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::sync::Arc;
 
 // Manual triggers
 struct State {
@@ -158,9 +158,9 @@ pub(crate) fn build_triggers(
                     );
                 }
             }
-            trigs.push(Rc::new(trig.clone()));
+            trigs.push(Arc::new(trig.clone()));
         }
-        Ok(Rc::new(trigs))
+        Ok(Arc::new(trigs))
     } else {
         crate::triggers_auto::build_triggers(ctx, span, vars, exp)
     }


### PR DESCRIPTION
When I originally created the `air`, `vir`, and `rust_verify` packages, I used `Rc` rather than `Arc`, thinking that we wouldn't need multiple threads.  Now I'm thinking that using `Rc` was short-sighted and that `Arc` will be more flexible.  (In particular, I'm starting to encounter situations where rustc calls multiple `rust_verify` callbacks, but not necessarily always in the same thread.)