### PR TITLE
Custom messages for precondition failures

### DIFF
--- a/verify/rust_verify/example/assertions.rs
+++ b/verify/rust_verify/example/assertions.rs
@@ -1,0 +1,18 @@
+extern crate builtin;
+use builtin::*;
+mod pervasive;
+use pervasive::*;
+
+fn main() {}
+
+fn test(b: bool) {
+    assert(b);
+}
+
+fn has_expectations(b:bool) {
+    requires(b);
+}
+
+fn fails_expectations() {
+    has_expectations(false);
+}

--- a/verify/rust_verify/example/pervasive.rs
+++ b/verify/rust_verify/example/pervasive.rs
@@ -9,6 +9,7 @@ pub fn assume(b: bool) {
 }
 
 #[proof]
+#[verifier(custom_req_err, "Assertion failure")]
 pub fn assert(b: bool) {
     requires(b);
     ensures(b);

--- a/verify/rust_verify/src/rust_to_vir_base.rs
+++ b/verify/rust_verify/src/rust_to_vir_base.rs
@@ -198,10 +198,12 @@ pub(crate) fn parse_attrs(attrs: &[Attribute]) -> Result<Vec<Attr>, VirErr> {
                 Some(box [AttrTree::Fun(_, arg, None)]) if arg == "pub_abstract" => {
                     v.push(Attr::Abstract)
                 }
-                Some(box [AttrTree::Fun(_, arg, Some(box [AttrTree::Fun(_, msg, None)]))]) if arg == "custom_req_err" => {
-                    v.push(Attr::CustomReqErr(msg))
+                Some(box [AttrTree::Fun(_, arg, None), AttrTree::Fun(_, msg, None)]) if arg == "custom_req_err" => {
+                    v.push(Attr::CustomReqErr(msg.clone()))
                 }
-                _ => return err_span_str(span, "unrecognized verifier attribute"),
+                _ => {
+                    return err_span_str(span, "unrecognized verifier attribute")
+                }
             },
             _ => {}
         }
@@ -271,7 +273,7 @@ pub(crate) fn get_verifier_attrs(attrs: &[Attribute]) -> Result<VerifierAttrs, V
             Attr::NoVerify => vs.do_verify = false,
             Attr::External => vs.external = true,
             Attr::Abstract => vs.is_abstract = true,
-            Attr::CustomReqErr(s) => vs.custom_req_err = s.clone(),
+            Attr::CustomReqErr(s) => vs.custom_req_err = Some(s.clone()),
             _ => {}
         }
     }

--- a/verify/rust_verify/src/rust_to_vir_func.rs
+++ b/verify/rust_verify/src/rust_to_vir_func.rs
@@ -139,6 +139,7 @@ pub(crate) fn check_item_fn<'tcx>(
         require: header.require,
         ensure: header.ensure,
         decrease: header.decrease,
+        custom_req_err: vattrs.custom_req_err,
         hidden: Arc::new(header.hidden),
         is_abstract: vattrs.is_abstract,
         body: if vattrs.do_verify { Some(vir_body) } else { None },

--- a/verify/rust_verify/src/rust_to_vir_func.rs
+++ b/verify/rust_verify/src/rust_to_vir_func.rs
@@ -185,6 +185,7 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         require: Arc::new(vec![]),
         ensure: Arc::new(vec![]),
         decrease: None,
+        custom_req_err: None,
         hidden: Arc::new(vec![]),
         is_abstract: false,
         body: None,

--- a/verify/rust_verify/tests/common/pervasive.rs
+++ b/verify/rust_verify/tests/common/pervasive.rs
@@ -14,6 +14,7 @@ pub const PERVASIVE: &str = crate::common::code_str! {
     }
 
     #[proof]
+    #[verifier(custom_req_err, "Assertion failure")]
     pub fn assert(b: bool) {
         requires(b);
         ensures(b);

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -271,6 +271,8 @@ pub struct FunctionX {
     pub ensure: Exprs,
     /// Decreases clause to ensure recursive function termination
     pub decrease: Option<(Expr, Typ)>,
+    /// Custom error message to display when a pre-condition fails
+    pub custom_req_err: Option<String>,
     /// List of functions that this function wants to view as opaque
     pub hidden: Idents,
     /// For public spec functions, is_abstract == true means that the body is private

--- a/verify/vir/src/func_to_air.rs
+++ b/verify/vir/src/func_to_air.rs
@@ -247,6 +247,12 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<(Commands, Com
             }
         }
         (Mode::Exec, _) | (Mode::Proof, _) => {
+            let msg = match &function.x.custom_req_err {
+                // Standard message
+                None => Some("failed precondition".to_string()),
+                // We don't highlight the failed precondition if the programmer supplied their own msg
+                Some(_) => None,
+            };
             req_ens_to_air(
                 ctx,
                 &mut decl_commands,
@@ -256,7 +262,7 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<(Commands, Com
                 &function.x.typ_params,
                 &param_typs,
                 &prefix_requires(&function.x.name),
-                &Some("failed precondition".to_string()),
+                &msg,
             )?;
             let mut ens_typs = (*param_typs).clone();
             let mut ens_params = (*function.x.params).clone();

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -295,9 +295,9 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     req_args.push(exp_to_expr(ctx, arg));
                 }
                 let e_req = Arc::new(ExprX::Apply(f_req, Arc::new(req_args)));
-                let description = match func.x.custom_req_err {
+                let description = match &func.x.custom_req_err {
                     None => Some("precondition not satisfied".to_string()),
-                    Some(s) => Some(s),
+                    Some(s) => Some(s.clone()),
                 };
                 let option_span = Arc::new(Some(Span { description, ..stm.span.clone() }));
                 stmts.push(Arc::new(StmtX::Assert(option_span, e_req)));

--- a/verify/vir/src/sst_to_air.rs
+++ b/verify/vir/src/sst_to_air.rs
@@ -295,7 +295,10 @@ fn stm_to_stmts(ctx: &Ctx, state: &mut State, stm: &Stm) -> Vec<Stmt> {
                     req_args.push(exp_to_expr(ctx, arg));
                 }
                 let e_req = Arc::new(ExprX::Apply(f_req, Arc::new(req_args)));
-                let description = Some("precondition not satisfied".to_string());
+                let description = match func.x.custom_req_err {
+                    None => Some("precondition not satisfied".to_string()),
+                    Some(s) => Some(s),
+                };
                 let option_span = Arc::new(Some(Span { description, ..stm.span.clone() }));
                 stmts.push(Arc::new(StmtX::Assert(option_span, e_req)));
             }


### PR DESCRIPTION
The primary motivation is so that assertion failures don't include a distracting "related info" pointing to its precondition.