### PR TITLE
Use full Paths, instead of just the name, to identify functions in vir

### DIFF
--- a/verify/rust_verify/src/context.rs
+++ b/verify/rust_verify/src/context.rs
@@ -8,7 +8,7 @@ use vir::ast::Mode;
 pub struct ErasureInfo {
     pub(crate) resolved_calls: Vec<(SpanData, ResolvedCall)>,
     pub(crate) condition_modes: Vec<(SpanData, Mode)>,
-    pub(crate) external_functions: Vec<air::ast::Ident>,
+    pub(crate) external_functions: Vec<vir::ast::Path>,
 }
 
 type ErasureInfoRef = std::rc::Rc<std::cell::RefCell<ErasureInfo>>;

--- a/verify/rust_verify/src/erase.rs
+++ b/verify/rust_verify/src/erase.rs
@@ -274,13 +274,13 @@ fn erase_block(ctxt: &Ctxt, is_exec: bool, block: &Block) -> Block {
     Block { stmts, id, rules, span, tokens: block.tokens.clone() }
 }
 
-fn erase_fn(ctxt: &Ctxt, f_span: &Span, f: &FnKind) -> Option<FnKind> {
-    let f_vir = &ctxt.functions_by_span[f_span];
+fn erase_fn(ctxt: &Ctxt, f: &FnKind) -> Option<FnKind> {
+    let FnKind(defaultness, sig, generics, body_opt) = f;
+    let f_vir = &ctxt.functions_by_span[&sig.span];
     match f_vir.x.mode {
         Mode::Spec | Mode::Proof => return None,
         Mode::Exec => {}
     }
-    let FnKind(defaultness, sig, generics, body_opt) = f;
     let FnSig { header: _, decl, span: _ } = sig;
     let FnDecl { inputs, output } = &**decl;
     let mut new_inputs: Vec<Param> = Vec::new();
@@ -318,7 +318,7 @@ fn erase_item(ctxt: &Ctxt, item: &Item) -> Vec<P<Item>> {
             if vattrs.external {
                 return vec![P(item.clone())];
             }
-            match erase_fn(ctxt, &item.span, kind) {
+            match erase_fn(ctxt, kind) {
                 None => return vec![],
                 Some(kind) => ItemKind::Fn(Box::new(kind)),
             }

--- a/verify/rust_verify/src/erase.rs
+++ b/verify/rust_verify/src/erase.rs
@@ -39,7 +39,7 @@
 use crate::rust_to_vir_base::get_verifier_attrs;
 use crate::util::{from_raw_span, vec_map};
 use crate::{unsupported, unsupported_unless};
-use air::ast::Ident;
+
 use rustc_ast::ast::{
     Block, Crate, Expr, ExprKind, FnDecl, FnKind, FnSig, Item, ItemKind, Local, ModKind, Param,
     Stmt, StmtKind,
@@ -48,7 +48,8 @@ use rustc_ast::ptr::P;
 use rustc_interface::interface::Compiler;
 use rustc_span::{Span, SpanData};
 use std::collections::HashMap;
-use std::sync::Arc;
+use vir::ast::Path;
+
 use vir::ast::{Function, Krate, Mode};
 use vir::modes::ErasureModes;
 
@@ -60,7 +61,7 @@ pub enum ResolvedCall {
     /// The call is to an operator like == or + that should be compiled.
     CompilableOperator,
     /// The call is to a function, and we record the resolved name of the function here.
-    Call(Ident),
+    Call(Path),
 }
 
 #[derive(Clone)]
@@ -73,16 +74,18 @@ pub struct ErasureHints {
     pub erasure_modes: ErasureModes,
     /// List of #[verifier(external)] functions.  (These don't appear in vir_crate,
     /// so we need to record them separately here.)
-    pub external_functions: Vec<Ident>,
+    pub external_functions: Vec<Path>,
 }
 
 #[derive(Clone)]
 pub struct Ctxt {
     /// Copy of the entire VIR crate that was created in the first run's HIR -> VIR transformation
     vir_crate: Krate,
-    /// Map each function name to its VIR Function, or to None if it is a #[verifier(external)]
+    /// Map each function path to its VIR Function, or to None if it is a #[verifier(external)]
     /// function
-    functions: HashMap<Ident, Option<Function>>,
+    functions: HashMap<Path, Option<Function>>,
+    /// Map each function span to its VIR Function, excluding #[verifier(external)] functions
+    functions_by_span: HashMap<Span, Function>,
     /// Details of each call in the first run's HIR
     calls: HashMap<Span, ResolvedCall>,
     /// Mode of each if/else or match condition, used to decide how to erase if/else and match
@@ -181,8 +184,8 @@ fn erase_expr_opt(ctxt: &Ctxt, is_exec: bool, expr: &Expr) -> Option<Expr> {
                     f_expr.clone(),
                     vec_map(args, |e| P(erase_expr(ctxt, is_exec, e))),
                 ),
-                ResolvedCall::Call(f_name) => {
-                    let f = &ctxt.functions[f_name];
+                ResolvedCall::Call(f_path) => {
+                    let f = &ctxt.functions[f_path];
                     if let Some(f) = f {
                         match f.x.mode {
                             Mode::Spec | Mode::Proof => return None,
@@ -271,8 +274,8 @@ fn erase_block(ctxt: &Ctxt, is_exec: bool, block: &Block) -> Block {
     Block { stmts, id, rules, span, tokens: block.tokens.clone() }
 }
 
-fn erase_fn(ctxt: &Ctxt, f_name: &String, f: &FnKind) -> Option<FnKind> {
-    let f_vir = &ctxt.functions[&Arc::new(f_name.clone())].as_ref().expect("erase_fn");
+fn erase_fn(ctxt: &Ctxt, f_span: &Span, f: &FnKind) -> Option<FnKind> {
+    let f_vir = &ctxt.functions_by_span[f_span];
     match f_vir.x.mode {
         Mode::Spec | Mode::Proof => return None,
         Mode::Exec => {}
@@ -315,7 +318,7 @@ fn erase_item(ctxt: &Ctxt, item: &Item) -> Vec<P<Item>> {
             if vattrs.external {
                 return vec![P(item.clone())];
             }
-            match erase_fn(ctxt, &item.ident.name.to_string(), kind) {
+            match erase_fn(ctxt, &item.span, kind) {
                 None => return vec![],
                 Some(kind) => ItemKind::Fn(Box::new(kind)),
             }
@@ -364,9 +367,11 @@ pub struct CompilerCallbacks {
 
 fn mk_ctxt(erasure_hints: &ErasureHints) -> Ctxt {
     let mut functions = HashMap::new();
+    let mut functions_by_span = HashMap::new();
     let mut calls: HashMap<Span, ResolvedCall> = HashMap::new();
     for f in &erasure_hints.vir_crate.functions {
-        functions.insert(f.x.name.clone(), Some(f.clone()));
+        functions.insert(f.x.path.clone(), Some(f.clone()));
+        functions_by_span.insert(from_raw_span(&f.span.raw_span), f.clone());
     }
     for name in &erasure_hints.external_functions {
         functions.insert(name.clone(), None);
@@ -385,6 +390,7 @@ fn mk_ctxt(erasure_hints: &ErasureHints) -> Ctxt {
     Ctxt {
         vir_crate: erasure_hints.vir_crate.clone(),
         functions,
+        functions_by_span,
         calls,
         condition_modes,
         var_modes,

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -14,7 +14,7 @@ use crate::util::unsupported_err_span;
 use crate::{err_unless, unsupported_err, unsupported_err_unless, unsupported_unless};
 use rustc_ast::Attribute;
 use rustc_hir::{
-    AssocItemKind, Crate, ForeignItem, ForeignItemId, ForeignItemKind, HirId, ImplItemKind, Item,
+    Crate, ForeignItem, ForeignItemId, ForeignItemKind, HirId, Item,
     ItemId, ItemKind, ModuleItems, QPath, TraitRef, TyKind,
 };
 use rustc_middle::ty::TyCtxt;

--- a/verify/rust_verify/src/rust_to_vir.rs
+++ b/verify/rust_verify/src/rust_to_vir.rs
@@ -14,8 +14,8 @@ use crate::util::unsupported_err_span;
 use crate::{err_unless, unsupported_err, unsupported_err_unless, unsupported_unless};
 use rustc_ast::Attribute;
 use rustc_hir::{
-    Crate, ForeignItem, ForeignItemId, ForeignItemKind, HirId, Item, ItemId, ItemKind, ModuleItems,
-    QPath, TraitRef, TyKind,
+    AssocItemKind, Crate, ForeignItem, ForeignItemId, ForeignItemKind, HirId, ImplItemKind, Item,
+    ItemId, ItemKind, ModuleItems, QPath, TraitRef, TyKind,
 };
 use rustc_middle::ty::TyCtxt;
 use std::collections::HashMap;
@@ -35,7 +35,8 @@ fn check_item<'tcx>(
             check_item_fn(
                 ctxt,
                 vir,
-                item.ident,
+                None,
+                item.def_id.to_def_id(),
                 visibility,
                 ctxt.tcx.hir().attrs(item.hir_id()),
                 sig,
@@ -189,7 +190,7 @@ fn check_item<'tcx>(
 }
 
 fn check_module<'tcx>(
-    tcx: TyCtxt<'tcx>,
+    _tcx: TyCtxt<'tcx>,
     module_path: &Path,
     module_items: &'tcx ModuleItems,
     item_to_module: &mut HashMap<ItemId, Path>,
@@ -200,18 +201,8 @@ fn check_module<'tcx>(
                 item_to_module.insert(*item_id, module_path.clone());
             }
             unsupported_unless!(trait_items.len() == 0, "trait definitions", trait_items);
-            // TODO: deduplicate with crate_to_vir
-            for id in impl_items {
-                let def_name = hack_get_def_name(tcx, id.def_id.to_def_id());
-                // TODO: check whether these implement the correct trait
-                unsupported_unless!(
-                    def_name == "assert_receiver_is_total_eq"
-                        || def_name == "eq"
-                        || def_name == "ne"
-                        || def_name == "assert_receiver_is_structural",
-                    "impl definition in module",
-                    id
-                );
+            for _id in impl_items {
+                // TODO?
             }
             for _id in foreign_items {
                 // TODO
@@ -232,7 +223,7 @@ fn check_foreign_item<'tcx>(
             check_foreign_item_fn(
                 ctxt,
                 vir,
-                item.ident,
+                item.def_id.to_def_id(),
                 item.span,
                 mk_visibility(&None, &item.vis),
                 ctxt.tcx.hir().attrs(item.hir_id()),

--- a/verify/rust_verify/src/rust_to_vir_func.rs
+++ b/verify/rust_verify/src/rust_to_vir_func.rs
@@ -1,7 +1,7 @@
 use crate::context::Context;
 use crate::rust_to_vir_base::{
-    check_generics, get_fuel, get_mode, get_var_mode, get_verifier_attrs, ident_to_var, ty_to_vir,
-    BodyCtxt,
+    check_generics, def_id_to_vir_path, get_fuel, get_mode, get_var_mode, get_verifier_attrs,
+    ident_to_var, ty_to_vir, BodyCtxt,
 };
 use crate::rust_to_vir_expr::{expr_to_vir, pat_to_var};
 use crate::util::{err_span_str, err_span_string, spanned_new, unsupported_err_span};
@@ -50,14 +50,15 @@ fn check_fn_decl<'tcx>(
 pub(crate) fn check_item_fn<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
-    id: Ident,
+    _self_path: Option<&'tcx rustc_hir::Path<'tcx>>,
+    id: rustc_span::def_id::DefId,
     visibility: vir::ast::Visibility,
     attrs: &[Attribute],
     sig: &'tcx FnSig<'tcx>,
     generics: &'tcx Generics,
     body_id: &BodyId,
 ) -> Result<(), VirErr> {
-    let name = Arc::new(ident_to_var(&id));
+    let path = def_id_to_vir_path(ctxt.tcx, id);
     let mode = get_mode(Mode::Exec, attrs);
     let ret_typ_mode = match sig {
         FnSig {
@@ -74,7 +75,7 @@ pub(crate) fn check_item_fn<'tcx>(
     let vattrs = get_verifier_attrs(attrs)?;
     if vattrs.external {
         let mut erasure_info = ctxt.erasure_info.borrow_mut();
-        erasure_info.external_functions.push(name);
+        erasure_info.external_functions.push(path);
         return Ok(());
     }
     let body = &ctxt.krate.bodies[body_id];
@@ -129,7 +130,7 @@ pub(crate) fn check_item_fn<'tcx>(
         _ => panic!("internal error: ret_typ"),
     };
     let func = FunctionX {
-        name,
+        path,
         visibility,
         mode,
         fuel,
@@ -152,7 +153,7 @@ pub(crate) fn check_item_fn<'tcx>(
 pub(crate) fn check_foreign_item_fn<'tcx>(
     ctxt: &Context<'tcx>,
     vir: &mut KrateX,
-    id: Ident,
+    id: rustc_span::def_id::DefId,
     span: Span,
     visibility: vir::ast::Visibility,
     attrs: &[Attribute],
@@ -172,10 +173,10 @@ pub(crate) fn check_foreign_item_fn<'tcx>(
         let vir_param = spanned_new(param.span, ParamX { name, typ, mode });
         vir_params.push(vir_param);
     }
-    let name = Arc::new(ident_to_var(&id));
+    let path = def_id_to_vir_path(ctxt.tcx, id);
     let params = Arc::new(vir_params);
     let func = FunctionX {
-        name,
+        path,
         visibility,
         fuel,
         mode,

--- a/verify/rust_verify/src/verifier.rs
+++ b/verify/rust_verify/src/verifier.rs
@@ -12,6 +12,7 @@ use rustc_span::{CharPos, FileName, MultiSpan, Span};
 use std::fs::File;
 use std::io::Write;
 use vir::ast::{Krate, Path, VirErr, VirErrX, Visibility};
+use vir::ast_util::path_to_string;
 use vir::def::SnapPos;
 use vir::model::Model as VModel;
 
@@ -247,7 +248,7 @@ impl Verifier {
             Self::run_commands(
                 air_context,
                 &commands,
-                &("Function-Decl ".to_string() + &function.x.name),
+                &("Function-Decl ".to_string() + &path_to_string(&function.x.path)),
             );
         }
 
@@ -264,7 +265,7 @@ impl Verifier {
             Self::run_commands(
                 air_context,
                 &decl_commands,
-                &("Function-Axioms ".to_string() + &function.x.name),
+                &("Function-Axioms ".to_string() + &path_to_string(&function.x.path)),
             );
 
             // Check termination
@@ -276,7 +277,7 @@ impl Verifier {
                 air_context,
                 &check_commands,
                 &vec![],
-                &("Function-Termination ".to_string() + &function.x.name),
+                &("Function-Termination ".to_string() + &path_to_string(&function.x.path)),
             );
         }
 
@@ -291,7 +292,7 @@ impl Verifier {
                 air_context,
                 &commands,
                 &snap_map,
-                &("Function-Def ".to_string() + &function.x.name),
+                &("Function-Def ".to_string() + &path_to_string(&function.x.path)),
             );
         }
 
@@ -399,7 +400,7 @@ impl Verifier {
                 writeln!(&mut file).expect("cannot write to vir file");
             }
             for func in vir_crate.functions.iter() {
-                writeln!(&mut file, "fn {} @ {:?}", func.x.name, func.span)
+                writeln!(&mut file, "fn {} @ {:?}", path_to_string(&func.x.path), func.span)
                     .expect("cannot write to vir file");
                 for param in func.x.params.iter() {
                     writeln!(

--- a/verify/vir/src/ast.rs
+++ b/verify/vir/src/ast.rs
@@ -161,7 +161,7 @@ pub enum HeaderExprX {
     Decreases(Expr, Typ),
     /// Make a function f opaque (definition hidden) within the current function body.
     /// (The current function body can later reveal f in specific parts of the current function body if desired.)
-    Hide(Ident),
+    Hide(Path),
 }
 
 /// Primitive constant values
@@ -192,7 +192,7 @@ pub enum ExprX {
     /// Call to function with given name, passing some type arguments and some expression arguments
     /// TODO: should be Path, not Ident
     /// Note: higher-order functions aren't yet supported
-    Call(Ident, Typs, Exprs),
+    Call(Path, Typs, Exprs),
     /// Construct datatype value of type Path and variant Ident, with field initializers Binders<Expr>
     Ctor(Path, Ident, Binders<Expr>),
     /// Read field from datatype
@@ -208,7 +208,7 @@ pub enum ExprX {
     /// Assign to local variable
     Assign(Expr, Expr),
     /// Reveal definition of an opaque function with some integer fuel amount
-    Fuel(Ident, u32),
+    Fuel(Path, u32),
     /// Header, which must appear at the beginning of a function or while loop.
     /// Note: this only appears temporarily during rust_to_vir construction, and should not
     /// appear in the final Expr produced by rust_to_vir (see vir::headers::read_header).
@@ -248,8 +248,7 @@ pub struct ParamX {
 pub type Function = Arc<Spanned<FunctionX>>;
 #[derive(Debug, Clone)]
 pub struct FunctionX {
-    /// TODO: should be Path, not Ident
-    pub name: Ident,
+    pub path: Path,
     pub visibility: Visibility,
     /// exec functions are compiled, proof/spec are erased
     /// exec/proof functions can have requires/ensures, spec cannot
@@ -274,7 +273,7 @@ pub struct FunctionX {
     /// Custom error message to display when a pre-condition fails
     pub custom_req_err: Option<String>,
     /// List of functions that this function wants to view as opaque
-    pub hidden: Idents,
+    pub hidden: Arc<Vec<Path>>,
     /// For public spec functions, is_abstract == true means that the body is private
     /// even though the function is public
     pub is_abstract: bool,

--- a/verify/vir/src/def.rs
+++ b/verify/vir/src/def.rs
@@ -1,3 +1,4 @@
+use crate::ast_util::str_ident;
 use air::ast::{Ident, Span};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -58,7 +59,6 @@ pub const NAT_CLIP: &str = "nClip";
 pub const U_INV: &str = "uInv";
 pub const I_INV: &str = "iInv";
 pub const ARCH_SIZE: &str = "SZ";
-pub const CHECK_DECREASE_INT: &str = "check_decrease_int";
 pub const DECREASE_AT_ENTRY: &str = "decrease%init";
 pub const SNAPSHOT_CALL: &str = "CALL";
 pub const UNIT: &str = "Unit";
@@ -81,6 +81,10 @@ pub const TYPE_ID_SINT: &str = "SINT";
 pub const PREFIX_TYPE_ID: &str = "TYPE%";
 pub const HAS_TYPE: &str = "has_type";
 pub const VARIANT_FIELD_SEPARATOR: &str = "/";
+
+pub fn check_decrease_int() -> crate::ast::Path {
+    Arc::new(vec![str_ident("check_decrease_int")])
+}
 
 pub fn suffix_global_id(ident: &Ident) -> Ident {
     Arc::new(ident.to_string() + SUFFIX_GLOBAL)

--- a/verify/vir/src/func_to_air.rs
+++ b/verify/vir/src/func_to_air.rs
@@ -5,7 +5,7 @@ use crate::def::{
     suffix_global_id, suffix_local_id, suffix_typ_param_id, SnapPos, Spanned, FUEL_BOOL,
     FUEL_BOOL_DEFAULT, FUEL_LOCAL, FUEL_TYPE, SUCC, ZERO,
 };
-use crate::sst_to_air::{exp_to_expr, typ_invariant, typ_to_air};
+use crate::sst_to_air::{exp_to_expr, path_to_air_ident, typ_invariant, typ_to_air};
 use crate::util::{vec_map, vec_map_result};
 use air::ast::{
     BinaryOp, Bind, BindX, Command, CommandX, Commands, DeclX, Expr, ExprX, MultiOp, Quant, Span,
@@ -74,7 +74,7 @@ fn func_body_to_air(
     function: &Function,
     body: &crate::ast::Expr,
 ) -> Result<(), VirErr> {
-    let id_fuel = prefix_fuel_id(&function.x.name);
+    let id_fuel = prefix_fuel_id(&path_to_air_ident(&function.x.path));
 
     // ast --> sst
     let body_exp = crate::ast_to_sst::expr_to_exp(&ctx, &body)?;
@@ -103,8 +103,8 @@ fn func_body_to_air(
     let def_body = if !is_recursive {
         body_expr
     } else {
-        let rec_f = suffix_global_id(&prefix_recursive(&function.x.name));
-        let fuel_nat_f = prefix_fuel_nat(&function.x.name);
+        let rec_f = suffix_global_id(&prefix_recursive(&path_to_air_ident(&function.x.path)));
+        let fuel_nat_f = prefix_fuel_nat(&path_to_air_ident(&function.x.path));
         let args = func_def_args(&function.x.typ_params, &function.x.params);
         let mut args_zero = args.clone();
         let mut args_fuel = args.clone();
@@ -136,7 +136,7 @@ fn func_body_to_air(
     };
     let e_forall = func_def_quant(
         ctx,
-        &suffix_global_id(&function.x.name),
+        &suffix_global_id(&path_to_air_ident(&function.x.path)),
         &function.x.typ_params,
         &function.x.params,
         def_body,
@@ -202,15 +202,16 @@ pub fn func_name_to_air(ctx: &Ctx, function: &Function) -> Result<Commands, VirE
     if let (Mode::Spec, Some((_, ret, _))) = (function.x.mode, function.x.ret.as_ref()) {
         // Declare the function symbol itself
         let typ = typ_to_air(ctx, &ret);
-        let name = suffix_global_id(&function.x.name);
+        let name = suffix_global_id(&path_to_air_ident(&function.x.path));
         let decl = Arc::new(DeclX::Fun(name, Arc::new(all_typs), typ));
         commands.push(Arc::new(CommandX::Global(decl)));
 
         // Check whether we need to declare the recursive version too
         if let Some(body) = &function.x.body {
             let body_exp = crate::ast_to_sst::expr_to_exp(&ctx, &body)?;
-            if crate::recursion::is_recursive_exp(ctx, &function.x.name, &body_exp) {
-                let rec_f = suffix_global_id(&prefix_recursive(&function.x.name));
+            if crate::recursion::is_recursive_exp(ctx, &function.x.path, &body_exp) {
+                let rec_f =
+                    suffix_global_id(&prefix_recursive(&path_to_air_ident(&function.x.path)));
                 let mut rec_typs =
                     vec_map(&*function.x.params, |param| typ_to_air(ctx, &param.x.typ));
                 rec_typs.push(str_typ(FUEL_TYPE));
@@ -233,7 +234,7 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<(Commands, Com
     let mut check_commands: Vec<Command> = Vec::new();
     match (function.x.mode, function.x.ret.as_ref()) {
         (Mode::Spec, Some((_, ret, _))) => {
-            let name = suffix_global_id(&function.x.name);
+            let name = suffix_global_id(&path_to_air_ident(&function.x.path));
 
             // Body
             if let Some(body) = &function.x.body {
@@ -274,7 +275,7 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<(Commands, Com
                 &function.x.require,
                 &function.x.typ_params,
                 &param_typs,
-                &prefix_requires(&function.x.name),
+                &prefix_requires(&path_to_air_ident(&function.x.path)),
                 &msg,
             )?;
             let mut ens_typs = (*param_typs).clone();
@@ -296,7 +297,7 @@ pub fn func_decl_to_air(ctx: &Ctx, function: &Function) -> Result<(Commands, Com
                 &function.x.ensure,
                 &function.x.typ_params,
                 &Arc::new(ens_typs),
-                &prefix_ensures(&function.x.name),
+                &prefix_ensures(&path_to_air_ident(&function.x.path)),
                 &None,
             )?;
         }

--- a/verify/vir/src/headers.rs
+++ b/verify/vir/src/headers.rs
@@ -1,10 +1,10 @@
-use crate::ast::{Expr, ExprX, Exprs, HeaderExprX, Ident, Stmt, StmtX, Typ, VirErr};
+use crate::ast::{Expr, ExprX, Exprs, HeaderExprX, Ident, Path, Stmt, StmtX, Typ, VirErr};
 use crate::ast_util::err_str;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct Header {
-    pub hidden: Vec<Ident>,
+    pub hidden: Vec<Path>,
     pub require: Exprs,
     pub ensure_id_typ: Option<(Ident, Typ)>,
     pub ensure: Exprs,
@@ -13,7 +13,7 @@ pub struct Header {
 }
 
 fn read_header_block(block: &mut Vec<Stmt>) -> Result<Header, VirErr> {
-    let mut hidden: Vec<Ident> = Vec::new();
+    let mut hidden: Vec<Path> = Vec::new();
     let mut require: Option<Exprs> = None;
     let mut ensure: Option<(Option<(Ident, Typ)>, Exprs)> = None;
     let mut invariant: Option<Exprs> = None;

--- a/verify/vir/src/modes.rs
+++ b/verify/vir/src/modes.rs
@@ -34,7 +34,7 @@ pub struct ErasureModes {
 }
 
 struct Typing {
-    pub(crate) funs: HashMap<Ident, Function>,
+    pub(crate) funs: HashMap<Path, Function>,
     pub(crate) datatypes: HashMap<Path, Datatype>,
     pub(crate) vars: ScopeMap<Ident, Mode>,
     pub(crate) erasure_modes: ErasureModes,
@@ -236,10 +236,10 @@ fn check_function(typing: &mut Typing, function: &Function) -> Result<(), VirErr
 }
 
 pub fn check_crate(krate: &Krate) -> Result<ErasureModes, VirErr> {
-    let mut funs: HashMap<Ident, Function> = HashMap::new();
+    let mut funs: HashMap<Path, Function> = HashMap::new();
     let mut datatypes: HashMap<Path, Datatype> = HashMap::new();
     for function in krate.functions.iter() {
-        funs.insert(function.x.name.clone(), function.clone());
+        funs.insert(function.x.path.clone(), function.clone());
     }
     for datatype in krate.datatypes.iter() {
         datatypes.insert(datatype.x.path.clone(), datatype.clone());

--- a/verify/vir/src/prelude.rs
+++ b/verify/vir/src/prelude.rs
@@ -1,6 +1,6 @@
 use crate::def::*;
+use crate::sst_to_air::path_to_air_ident;
 use air::ast::Ident;
-use air::ast_util::str_ident;
 use air::printer::{macro_push_node, str_to_node};
 use air::{node, nodes_vec};
 use sise::Node;
@@ -24,7 +24,8 @@ pub(crate) fn prelude_nodes() -> Vec<Node> {
     let u_inv = str_to_node(U_INV);
     let i_inv = str_to_node(I_INV);
     let arch_size = str_to_node(ARCH_SIZE);
-    let check_decrease_int = str_to_node(&suffix_global_id(&str_ident(CHECK_DECREASE_INT)));
+    let check_decrease_int =
+        str_to_node(&suffix_global_id(&path_to_air_ident(&check_decrease_int())));
     #[allow(non_snake_case)]
     let Unit = str_to_node(UNIT);
     #[allow(non_snake_case)]

--- a/verify/vir/src/recursion.rs
+++ b/verify/vir/src/recursion.rs
@@ -1,10 +1,8 @@
-use crate::ast::{BinaryOp, Constant, Function, Ident, Params, Typ, TypX, UnaryOp, VirErr};
+use crate::ast::{BinaryOp, Constant, Function, Ident, Params, Path, Typ, TypX, UnaryOp, VirErr};
 use crate::ast_util::err_str;
 use crate::ast_visitor::map_expr_visitor;
 use crate::context::Ctx;
-use crate::def::{
-    prefix_recursive, suffix_rename, Spanned, CHECK_DECREASE_INT, DECREASE_AT_ENTRY, FUEL_PARAM,
-};
+use crate::def::{check_decrease_int, suffix_rename, Spanned, DECREASE_AT_ENTRY, FUEL_PARAM};
 use crate::scc::Graph;
 use crate::sst::{BndX, Exp, ExpX, Exps, Stm, StmX};
 use crate::sst_visitor::{exp_rename_vars, map_exp_visitor, map_stm_visitor};
@@ -15,12 +13,12 @@ use std::sync::Arc;
 
 #[derive(Clone)]
 struct Ctxt<'a> {
-    recursive_function_name: Ident,
+    recursive_function_path: Path,
     params: Params,
     decreases_at_entry: Ident,
     decreases_exp: Exp,
     decreases_typ: Typ,
-    scc_rep: Ident,
+    scc_rep: Path,
     ctx: &'a Ctx,
 }
 
@@ -31,7 +29,8 @@ fn check_decrease(ctxt: &Ctxt, exp: &Exp) -> Exp {
         TypX::Int(_) => {
             // 0 <= decreases_exp < decreases_at_entry
             let call = ExpX::Call(
-                str_ident(CHECK_DECREASE_INT),
+                false,
+                check_decrease_int(),
                 Arc::new(vec![]),
                 Arc::new(vec![exp.clone(), decreases_at_entry]),
             );
@@ -62,7 +61,7 @@ fn check_decrease_rename(ctxt: &Ctxt, span: &Span, args: &Exps) -> Exp {
     check_decrease(ctxt, &e_dec)
 }
 
-fn update_decreases_exp<'a>(ctxt: &'a Ctxt, name: &Ident) -> Result<Ctxt<'a>, VirErr> {
+fn update_decreases_exp<'a>(ctxt: &'a Ctxt, name: &Path) -> Result<Ctxt<'a>, VirErr> {
     let function = ctxt.ctx.func_map.get(name).expect("func_map should hold all functions");
     let (new_decreases_expr, _) = function
         .x
@@ -80,8 +79,8 @@ fn terminates(ctxt: &Ctxt, exp: &Exp) -> Result<Exp, VirErr> {
         ExpX::Const(_) | ExpX::Var(_) | ExpX::Old(_, _) => {
             Ok(Spanned::new(exp.span.clone(), ExpX::Const(Constant::Bool(true))))
         }
-        ExpX::Call(x, _, args) => {
-            let mut e = if *x == ctxt.recursive_function_name
+        ExpX::Call(_, x, _, args) => {
+            let mut e = if *x == ctxt.recursive_function_path
                 || ctxt.ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep
             {
                 let new_ctxt = update_decreases_exp(&ctxt, x)?;
@@ -167,7 +166,7 @@ fn terminates(ctxt: &Ctxt, exp: &Exp) -> Result<Exp, VirErr> {
     }
 }
 
-pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Ident, body: &Exp) -> bool {
+pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Path, body: &Exp) -> bool {
     if ctx.func_call_graph.get_scc_size(name) > 1 {
         // This function is part of a mutually recursive component
         true
@@ -175,7 +174,7 @@ pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Ident, body: &Exp) -> bool {
         // Check for self-recursion, which SCC computation does not account for
         let mut recurse = false;
         map_exp_visitor(body, &mut |exp| match &exp.x {
-            ExpX::Call(x, _, _) if x == name => {
+            ExpX::Call(_, x, _, _) if x == name => {
                 recurse = true;
                 exp.clone()
             }
@@ -185,7 +184,7 @@ pub(crate) fn is_recursive_exp(ctx: &Ctx, name: &Ident, body: &Exp) -> bool {
     }
 }
 
-pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Ident, body: &Stm) -> bool {
+pub(crate) fn is_recursive_stm(ctx: &Ctx, name: &Path, body: &Stm) -> bool {
     if ctx.func_call_graph.get_scc_size(name) > 1 {
         // This function is part of a mutually recursive component
         true
@@ -233,7 +232,7 @@ pub(crate) fn check_termination_exp(
     function: &Function,
     body: &Exp,
 ) -> Result<(bool, Commands, Exp), VirErr> {
-    if !is_recursive_exp(ctx, &function.x.name, body) {
+    if !is_recursive_exp(ctx, &function.x.path, body) {
         return Ok((false, Arc::new(vec![]), body.clone()));
     }
 
@@ -245,10 +244,10 @@ pub(crate) fn check_termination_exp(
     };
     let decreases_exp = crate::ast_to_sst::expr_to_exp(ctx, &decreases_expr)?;
     let decreases_at_entry = str_ident(DECREASE_AT_ENTRY);
-    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.path);
     let scc_rep_clone = scc_rep.clone();
     let ctxt = Ctxt {
-        recursive_function_name: function.x.name.clone(),
+        recursive_function_path: function.x.path.clone(),
         params: function.x.params.clone(),
         decreases_at_entry,
         decreases_exp,
@@ -281,13 +280,15 @@ pub(crate) fn check_termination_exp(
 
     // New body: substitute rec%f(args, fuel) for f(args)
     let body = map_exp_visitor(&body, &mut |exp| match &exp.x {
-        ExpX::Call(x, typs, args)
-            if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == scc_rep_clone =>
+        ExpX::Call(_, x, typs, args)
+            if *x == function.x.path || ctx.func_call_graph.get_scc_rep(x) == scc_rep_clone =>
         {
-            let rec_x = prefix_recursive(x);
             let mut args = (**args).clone();
             args.push(Spanned::new(exp.span.clone(), ExpX::Var(str_ident(FUEL_PARAM))));
-            Spanned::new(exp.span.clone(), ExpX::Call(rec_x, typs.clone(), Arc::new(args)))
+            Spanned::new(
+                exp.span.clone(),
+                ExpX::Call(true, x.clone(), typs.clone(), Arc::new(args)),
+            )
         }
         _ => exp.clone(),
     });
@@ -300,7 +301,7 @@ pub(crate) fn check_termination_stm(
     function: &Function,
     body: &Stm,
 ) -> Result<Stm, VirErr> {
-    if !is_recursive_stm(ctx, &function.x.name, body) {
+    if !is_recursive_stm(ctx, &function.x.path, body) {
         return Ok(body.clone());
     }
 
@@ -312,9 +313,9 @@ pub(crate) fn check_termination_stm(
     };
     let decreases_exp = crate::ast_to_sst::expr_to_exp(ctx, &decreases_expr)?;
     let decreases_at_entry = str_ident(DECREASE_AT_ENTRY);
-    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.name);
+    let scc_rep = ctx.func_call_graph.get_scc_rep(&function.x.path);
     let ctxt = Ctxt {
-        recursive_function_name: function.x.name.clone(),
+        recursive_function_path: function.x.path.clone(),
         params: function.x.params.clone(),
         decreases_at_entry,
         decreases_exp,
@@ -324,7 +325,7 @@ pub(crate) fn check_termination_stm(
     };
     let stm = map_stm_visitor(body, &mut |s| match &s.x {
         StmX::Call(x, _, args, _)
-            if *x == function.x.name || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
+            if *x == function.x.path || ctx.func_call_graph.get_scc_rep(x) == ctxt.scc_rep =>
         {
             let new_ctxt = update_decreases_exp(&ctxt, x)?;
             let check = check_decrease_rename(&new_ctxt, &s.span, &args);
@@ -348,8 +349,8 @@ pub(crate) fn check_termination_stm(
 }
 
 fn add_call_graph_edges(
-    call_graph: &mut Graph<Ident>,
-    src: &Ident,
+    call_graph: &mut Graph<Path>,
+    src: &Path,
     expr: &crate::ast::Expr,
 ) -> Result<crate::ast::Expr, VirErr> {
     use crate::ast::ExprX;
@@ -362,13 +363,13 @@ fn add_call_graph_edges(
 }
 
 pub(crate) fn expand_call_graph(
-    call_graph: &mut Graph<Ident>,
+    call_graph: &mut Graph<Path>,
     function: &Function,
 ) -> Result<(), VirErr> {
     // We only traverse expressions (not statements), since calls only appear in the former (see ast.rs)
     if let Some(body) = &function.x.body {
         map_expr_visitor(body, &mut |expr| {
-            add_call_graph_edges(call_graph, &function.x.name, expr)
+            add_call_graph_edges(call_graph, &function.x.path, expr)
         })?;
     }
     Ok(())

--- a/verify/vir/src/sst.rs
+++ b/verify/vir/src/sst.rs
@@ -27,8 +27,8 @@ pub type Exps = Arc<Vec<Exp>>;
 pub enum ExpX {
     Const(Constant),
     Var(Ident),
-    Old(Ident, Ident),       // used only during sst_to_air to generate AIR Old
-    Call(Ident, Typs, Exps), // call to spec function
+    Old(Ident, Ident), // used only during sst_to_air to generate AIR Old
+    Call(/* recursive: */ bool, Path, Typs, Exps), // call to spec function
     Ctor(Path, Ident, Binders<Exp>),
     Field { lhs: Exp, datatype: Path, field_name: Ident },
     Unary(UnaryOp, Exp),
@@ -48,7 +48,7 @@ pub type Stm = Arc<Spanned<StmX>>;
 pub type Stms = Arc<Vec<Stm>>;
 #[derive(Debug)]
 pub enum StmX {
-    Call(Ident, Typs, Exps, Option<Dest>), // call to exec/proof function
+    Call(Path, Typs, Exps, Option<Dest>), // call to exec/proof function
     Assert(Exp),
     Assume(Exp),
     Decl {
@@ -58,7 +58,7 @@ pub enum StmX {
         init: bool,
     },
     Assign(Exp, Exp),
-    Fuel(Ident, u32),
+    Fuel(Path, u32),
     If(Exp, Stm, Option<Stm>),
     While {
         cond: Exp,

--- a/verify/vir/src/sst_visitor.rs
+++ b/verify/vir/src/sst_visitor.rs
@@ -18,13 +18,15 @@ where
         ExpX::Const(_) => f(exp, map),
         ExpX::Var(_) => f(exp, map),
         ExpX::Old(_, _) => f(exp, map),
-        ExpX::Call(x, typs, es) => {
+        ExpX::Call(rec, x, typs, es) => {
             let mut exps: Vec<Exp> = Vec::new();
             for e in es.iter() {
                 exps.push(map_exp_visitor_bind(e, map, f)?);
             }
-            let exp =
-                Spanned::new(exp.span.clone(), ExpX::Call(x.clone(), typs.clone(), Arc::new(exps)));
+            let exp = Spanned::new(
+                exp.span.clone(),
+                ExpX::Call(*rec, x.clone(), typs.clone(), Arc::new(exps)),
+            );
             f(&exp, map)
         }
         ExpX::Ctor(path, ident, binders) => {

--- a/verify/vir/src/triggers.rs
+++ b/verify/vir/src/triggers.rs
@@ -16,14 +16,14 @@ struct State {
 
 fn check_trigger_expr(exp: &Exp, free_vars: &mut HashSet<Ident>) -> Result<(), VirErr> {
     match &exp.x {
-        ExpX::Call(_, _, _) | ExpX::Field { .. } | ExpX::Unary(UnaryOp::Trigger(_), _) => {}
+        ExpX::Call(_, _, _, _) | ExpX::Field { .. } | ExpX::Unary(UnaryOp::Trigger(_), _) => {}
         // REVIEW: Z3 allows some arithmetic, but it's not clear we want to allow it
         _ => {
             return err_str(&exp.span, "trigger must be a function call or a field access");
         }
     }
     let mut f = |exp: &Exp, _: &mut _| match &exp.x {
-        ExpX::Const(_) | ExpX::Call(_, _, _) | ExpX::Field { .. } | ExpX::Ctor(_, _, _) => {
+        ExpX::Const(_) | ExpX::Call(_, _, _, _) | ExpX::Field { .. } | ExpX::Ctor(_, _, _) => {
             Ok(exp.clone())
         }
         ExpX::Var(x) => {

--- a/verify/vir/src/well_formed.rs
+++ b/verify/vir/src/well_formed.rs
@@ -1,11 +1,11 @@
-use crate::ast::{Datatype, Expr, ExprX, Function, Ident, Krate, Mode, Path, VirErr};
+use crate::ast::{Datatype, Expr, ExprX, Function, Krate, Mode, Path, VirErr};
 use crate::ast_util::err_string;
 use crate::ast_visitor::map_expr_visitor;
 use crate::datatype_to_air::is_datatype_transparent;
 use std::collections::HashMap;
 
 struct Ctxt {
-    pub(crate) funs: HashMap<Ident, Function>,
+    pub(crate) funs: HashMap<Path, Function>,
     pub(crate) dts: HashMap<Path, Datatype>,
 }
 
@@ -71,7 +71,7 @@ pub fn check_crate(krate: &Krate) -> Result<(), VirErr> {
     let funs = krate
         .functions
         .iter()
-        .map(|function| (function.x.name.clone(), function.clone()))
+        .map(|function| (function.x.path.clone(), function.clone()))
         .collect();
     let dts = krate
         .datatypes


### PR DESCRIPTION
All tests still pass.